### PR TITLE
Fix loop stack management

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -101,3 +101,9 @@ impl PartialOrd for Func {
         None
     }
 }
+
+impl<T> Spanned<T> {
+    pub fn span(&self) -> Span {
+        self.1.clone()
+    }
+}

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -19,7 +19,9 @@ pub enum Bytecode {
 
     // Stack manipulation
     Pop,
+    RemoveIndex,
     Swap,
+    Dup,
     GetStackPtr,
     SetStackPtr,
 
@@ -95,7 +97,9 @@ impl Bytecode {
             Instruction::IfTrue(label) => Bytecode::IfTrue(label_mapper.get(label)?),
             Instruction::IfFalse(label) => Bytecode::IfFalse(label_mapper.get(label)?),
             Instruction::Pop => Bytecode::Pop,
+            Instruction::RemoveIndex => Bytecode::RemoveIndex,
             Instruction::Swap => Bytecode::Swap,
+            Instruction::Dup => Bytecode::Dup,
             Instruction::GetStackPtr => Bytecode::GetStackPtr,
             Instruction::SetStackPtr => Bytecode::SetStackPtr,
             Instruction::Call(num_args) => Bytecode::Call(num_args),

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -124,6 +124,7 @@ impl Bytecode {
     ) -> Result<RuntimeValue, CompileError> {
         let res = match value {
             IrValue::Null => RuntimeValue::Null,
+            IrValue::Uninit => RuntimeValue::Uninit,
             IrValue::Bool(b) => RuntimeValue::Bool(b),
             IrValue::Int(i) => RuntimeValue::Int(i),
             IrValue::Num(n) => RuntimeValue::Num(n),

--- a/src/bytecode_interpreter.rs
+++ b/src/bytecode_interpreter.rs
@@ -341,6 +341,7 @@ where
                 RuntimeValue::Int(i) => eprint!("{}", format!("{i}").yellow()),
                 RuntimeValue::Str(s) => eprint!("{}", format!("{s:?}").green()),
                 RuntimeValue::Uninit => eprint!("{}", "uninit".red()),
+                RuntimeValue::List(l) => eprint!("{}", format!("[..; {}]", l.len()).blue()),
                 _ => eprint!("{}", format!("{val}").blue()),
             }
         }

--- a/src/bytecode_interpreter.rs
+++ b/src/bytecode_interpreter.rs
@@ -340,6 +340,7 @@ where
             match val {
                 RuntimeValue::Int(i) => eprint!("{}", format!("{i}").yellow()),
                 RuntimeValue::Str(s) => eprint!("{}", format!("{s:?}").green()),
+                RuntimeValue::Uninit => eprint!("{}", "uninit".red()),
                 _ => eprint!("{}", format!("{val}").blue()),
             }
         }

--- a/src/bytecode_interpreter.rs
+++ b/src/bytecode_interpreter.rs
@@ -138,8 +138,19 @@ where
                     self.pop_stack()?;
                 }
 
+                Bytecode::RemoveIndex => {
+                    let index = self.pop_stack()?.address()?;
+                    debug_assert!(index < self.stack.len());
+                    self.stack.remove(index);
+                }
+
                 Bytecode::Swap => {
                     self.swap();
+                }
+
+                Bytecode::Dup => {
+                    let val = self.peek_stack()?.clone();
+                    self.push_stack(val);
                 }
 
                 Bytecode::GetStackPtr => {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -351,21 +351,18 @@ impl Compiler {
                     .compile_var_assign(
                         expr,
                         &loop_name,
-                        Program::from_instructions(vec![GetStackPtr], expr.1.clone()),
+                        Program::from_instructions(vec![GetStackPtr], expr.span()),
                     )?
-                    .then_instruction(Pop, expr.1.clone());
+                    .then_instruction(Pop, expr.span());
 
                 let program = register_loop
-                    .then_instruction(Value(IrValue::Null), expr.1.clone())
-                    .then_instruction(Instruction::Label(cond_label), expr.1.clone())
+                    .then_instruction(Value(IrValue::Null), expr.span())
+                    .then_instruction(Instruction::Label(cond_label), expr.span())
                     .then_program(self.compile_expr(cond)?)
                     .then_instruction(IfFalse(end_label), cond.1.clone())
                     .then_program(self.compile_expr(body)?)
-                    .then_instructions(vec![Swap, Pop, Goto(cond_label)], expr.1.clone())
-                    .then_instructions(
-                        vec![Instruction::Label(end_label), Swap, Pop],
-                        expr.1.clone(),
-                    );
+                    .then_instructions(vec![Swap, Pop, Goto(cond_label)], expr.span())
+                    .then_instructions(vec![Instruction::Label(end_label), Swap, Pop], expr.span());
 
                 self.vars.remove_local(&loop_name);
 
@@ -413,38 +410,38 @@ impl Compiler {
                         &loop_name,
                         Program::from_instructions(
                             vec![GetStackPtr, Value(IrValue::Int(1)), Add],
-                            expr.1.clone(),
+                            expr.span(),
                         ),
                     )?
-                    .then_instruction(Pop, expr.1.clone());
+                    .then_instruction(Pop, expr.span());
 
                 let iterable_name = format!("{loop_name}_iter");
                 let iterator = self
                     .compile_expr(iterable)?
-                    .then_instruction(ToIter, iterable.1.clone());
+                    .then_instruction(ToIter, iterable.span());
                 let register_iterable = self
                     .compile_var_assign(expr, &iterable_name, iterator)?
-                    .then_instruction(Pop, iterable.1.clone());
+                    .then_instruction(Pop, iterable.span());
 
                 let program = register_loop
                     .then_program(register_iterable)
-                    .then_instruction(Value(IrValue::Null), expr.1.clone())
-                    .then_instruction(Instruction::Label(iter_label), expr.1.clone())
+                    .then_instruction(Value(IrValue::Null), expr.span())
+                    .then_instruction(Instruction::Label(iter_label), expr.span())
                     .then_program(
                         self.compile_var_load(expr, &iterable_name)?
-                            .then_instructions(vec![NextIter, IfFalse(end_label)], expr.1.clone()),
+                            .then_instructions(vec![NextIter, IfFalse(end_label)], expr.span()),
                     )
                     .then_program(
                         self.compile_var_assign(
                             expr,
                             loop_var,
-                            Program::from_instruction(Swap, expr.1.clone()),
+                            Program::from_instruction(Swap, expr.span()),
                         )?
-                        .then_instruction(Pop, expr.1.clone()),
+                        .then_instruction(Pop, expr.span()),
                     )
                     .then_program(self.compile_expr(body)?)
-                    .then_instructions(vec![Swap, Pop, Goto(iter_label)], expr.1.clone())
-                    .then_instruction(Instruction::Label(end_label), expr.1.clone())
+                    .then_instructions(vec![Swap, Pop, Goto(iter_label)], expr.span())
+                    .then_instruction(Instruction::Label(end_label), expr.span())
                     .then_instructions(vec![Swap, Pop, Swap, Pop], expr.span());
 
                 self.vars.remove_local(&iterable_name);

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -410,7 +410,7 @@ impl Compiler {
                         expr,
                         &loop_name,
                         Program::from_instructions(
-                            vec![GetStackPtr, Value(IrValue::Int(1)), Sub],
+                            vec![GetStackPtr, Value(IrValue::Int(1)), Add],
                             expr.1.clone(),
                         ),
                     )?
@@ -607,8 +607,7 @@ impl Compiler {
             .map(|(name, _)| {
                 name.strip_prefix("!loop_")
                     .unwrap()
-                    .strip_suffix("_iter")
-                    .unwrap()
+                    .trim_end_matches("_iter")
                     .parse()
                     .expect("loop name is not a number")
             })

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -603,9 +603,8 @@ impl Compiler {
 
         if self.vars.get(name).is_none() {
             // Allocate stack space for new local variable if it doesn't exist
-            program.add_instruction(Value(IrValue::Null), expr.1.clone());
 
-            dbg!(name);
+            program.add_instruction(Value(IrValue::Uninit), expr.1.clone());
 
             let offset = self.vars.cur_scope_len();
             self.vars.set_local(name.clone(), offset);

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,6 +1,9 @@
 // TODO: Make all arguments generic/polymorphic, generate code for all possible types. Type inference.
 
-use std::{collections::HashMap, iter};
+use std::{
+    collections::{HashMap, HashSet},
+    iter,
+};
 
 use crate::{
     ast::{BinaryOp, Expr, Span, Spanned, UnaryOp, Value as AstValue},
@@ -779,3 +782,82 @@ pub enum CompileError {
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct Label(pub usize);
+
+fn find_all_assignments(expr: &Spanned<Expr>) -> Vec<Spanned<String>> {
+    fn find_all_assignments_inner(expr: &Spanned<Expr>) -> Vec<Spanned<&str>> {
+        match &expr.0 {
+            Expr::Let(local, val) => {
+                let mut res = find_all_assignments_inner(val);
+                res.push(Spanned(local, expr.span()));
+                res
+            }
+
+            Expr::Break | Expr::Continue | Expr::Value(_) | Expr::ParseError | Expr::Local(_) => {
+                vec![]
+            }
+
+            Expr::List(items) => items.iter().flat_map(find_all_assignments_inner).collect(),
+
+            Expr::Index(value, index) => {
+                let mut res = find_all_assignments_inner(value);
+                res.extend(find_all_assignments_inner(index));
+                res
+            }
+
+            Expr::If(cond, a, b) => {
+                let mut res = find_all_assignments_inner(cond);
+                res.extend(find_all_assignments_inner(a));
+                res.extend(find_all_assignments_inner(b));
+                res
+            }
+
+            Expr::While(cond, body) => {
+                let mut res = find_all_assignments_inner(cond);
+                res.extend(find_all_assignments_inner(body));
+                res
+            }
+
+            Expr::For(loop_var, iterable, body) => {
+                let mut res = vec![Spanned(loop_var.as_str(), expr.span())];
+                res.extend(find_all_assignments_inner(iterable));
+                res.extend(find_all_assignments_inner(body));
+                res
+            }
+
+            Expr::Call(func, args) => {
+                let mut res = find_all_assignments_inner(func);
+                res.extend(args.iter().flat_map(find_all_assignments_inner));
+                res
+            }
+
+            Expr::MethodCall(target, _, args) => {
+                let mut res = find_all_assignments_inner(target);
+                res.extend(args.iter().flat_map(find_all_assignments_inner));
+                res
+            }
+
+            Expr::Unary(_, sub_expr) => find_all_assignments_inner(sub_expr),
+
+            Expr::Binary(lhs, _, rhs) => {
+                let mut res = find_all_assignments_inner(lhs);
+                res.extend(find_all_assignments_inner(rhs));
+                res
+            }
+
+            Expr::Sequence(exprs) => exprs.iter().flat_map(find_all_assignments_inner).collect(),
+
+            Expr::Block(sub_expr) => find_all_assignments_inner(sub_expr),
+
+            Expr::Return(val) => find_all_assignments_inner(val),
+
+            Expr::Print(sub_expr) => find_all_assignments_inner(sub_expr),
+        }
+    }
+
+    let mut seen = HashSet::new();
+    find_all_assignments_inner(expr)
+        .into_iter()
+        .filter(|Spanned(name, _)| seen.insert(*name))
+        .map(|Spanned(name, span)| Spanned(name.to_string(), span))
+        .collect()
+}

--- a/src/ir_value.rs
+++ b/src/ir_value.rs
@@ -7,6 +7,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub enum IrValue {
     Null,
+    Uninit,
     Bool(bool),
     Int(isize),
     Num(RuntimeNumber),

--- a/src/runtime_value.rs
+++ b/src/runtime_value.rs
@@ -20,6 +20,7 @@ pub mod set;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RuntimeValue {
     Null,
+    Uninit,
     Bool(bool),
     Int(isize),
     Num(RuntimeNumber),
@@ -41,6 +42,7 @@ impl RuntimeValue {
     pub fn kind_str(&self) -> &str {
         match self {
             RuntimeValue::Null => "null",
+            RuntimeValue::Uninit => "uninitialized",
             RuntimeValue::Bool(_) => "boolean",
             RuntimeValue::Int(_) => "integer",
             RuntimeValue::Num(_) => "number",
@@ -212,6 +214,7 @@ impl RuntimeValue {
         match self {
             RuntimeValue::Bool(b) => *b,
             RuntimeValue::Null => false,
+            RuntimeValue::Uninit => false,
             RuntimeValue::Int(n) => *n != 0,
             RuntimeValue::Num(n) => n.bool(),
             RuntimeValue::Str(s) => !s.is_empty(),
@@ -244,6 +247,7 @@ impl std::fmt::Display for RuntimeValue {
 
         match self {
             RuntimeValue::Null => write!(f, "null"),
+            RuntimeValue::Uninit => write!(f, "uninitialized"),
             RuntimeValue::Bool(b) => write!(f, "{b}"),
             RuntimeValue::Int(n) => write!(f, "{n}"),
             RuntimeValue::Num(n) => write!(f, "{n}"),

--- a/src/scoped_map.rs
+++ b/src/scoped_map.rs
@@ -78,7 +78,9 @@ where
     pub fn set(&mut self, key: K, val: V) {
         match self.get_mut(&key) {
             Some(existing) => *existing.inner() = val,
-            None => self.set_local(key, val),
+            None => {
+                self.set_local(key, val);
+            }
         }
     }
 
@@ -86,8 +88,8 @@ where
         self.scopes.last().unwrap().get(name)
     }
 
-    pub fn set_local(&mut self, name: K, val: V) {
-        self.scopes.last_mut().unwrap().insert(name, val);
+    pub fn set_local(&mut self, name: K, val: V) -> Option<V> {
+        self.scopes.last_mut().unwrap().insert(name, val)
     }
 
     pub fn cur_scope_len(&self) -> usize {

--- a/tests/linefeed/for_loops.rs
+++ b/tests/linefeed/for_loops.rs
@@ -1,8 +1,6 @@
-use indoc::indoc;
-
 use crate::helpers::{
     eval_and_assert,
-    output::{contains, empty, equals},
+    output::{empty, equals},
 };
 
 eval_and_assert!(

--- a/tests/linefeed/scope.rs
+++ b/tests/linefeed/scope.rs
@@ -76,5 +76,5 @@ eval_and_assert!(
         x = x + 1; # error
     "#},
     empty(), // compilation fails, so no output
-    contains("Error: No such variable 'x' in scope")
+    contains("Type mismatch: Cannot add types 'uninitialized' and 'number'")
 );


### PR DESCRIPTION
Loops _sort_ of worked, but completely screwed up the stack when allocating variables inside them.

This PR adds doc comments that more carefully explain how the stack is managed for a loop. More importantly, it changes how variable allocation works: all variables in a function (or top scope) are now pre-allocated once the function initially runs. This avoids problems with allocating the same variable multiple times in loops, and it lets the variable "leak" out of scope, like we want with our scoping rules.