### PR TITLE
Preallocate temporary loop variables

### DIFF
--- a/linefeed/src/compiler.rs
+++ b/linefeed/src/compiler.rs
@@ -513,7 +513,10 @@ impl Compiler {
                     .compile_var_assign(
                         expr,
                         &loop_vars.stack_ptr_var,
-                        Program::from_instructions(vec![GetStackPtr], expr.span()),
+                        Program::from_instructions(
+                            vec![GetStackPtr, ConstantInt(1), Add],
+                            expr.span(),
+                        ),
                     )?
                     .then_instruction(Pop, expr.span());
 

--- a/linefeed/src/compiler.rs
+++ b/linefeed/src/compiler.rs
@@ -384,8 +384,6 @@ impl Compiler {
             Expr::While(cond, body) => {
                 let (cond_label, end_label) = (self.new_label(), self.new_label());
 
-                dbg!(&self.vars);
-
                 let loop_vars = make_loop_vars(expr.span());
 
                 self.loop_labels

--- a/linefeed/src/compiler/analysis.rs
+++ b/linefeed/src/compiler/analysis.rs
@@ -1,20 +1,20 @@
 use std::collections::HashSet;
 
 use crate::{
-    compiler::ir_value::IrValue,
+    compiler::{ir_value::IrValue, make_loop_vars},
     grammar::ast::{Expr, Pattern, Spanned},
 };
 
 pub fn find_all_assignments(expr: &Spanned<Expr>) -> Vec<Spanned<String>> {
-    fn find_all_assignments_inner<'src>(expr: &Spanned<Expr<'src>>) -> Vec<Spanned<&'src str>> {
+    fn find_all_assignments_inner<'src>(expr: &Spanned<Expr<'src>>) -> Vec<Spanned<String>> {
         fn resolve_assignment_target<'src>(
             target: &Spanned<Pattern<'src>>,
-        ) -> Vec<Spanned<&'src str>> {
+        ) -> Vec<Spanned<String>> {
             match &target.0 {
-                Pattern::Ident(local) => vec![Spanned(local, target.span())],
+                Pattern::Ident(local) => vec![Spanned(local.to_string(), target.span())],
                 Pattern::Sequence(patterns) => patterns
                     .iter()
-                    .flat_map(|pattern| resolve_assignment_target(pattern))
+                    .flat_map(resolve_assignment_target)
                     .collect(),
                 Pattern::Index(target, index) => {
                     let mut res = find_all_assignments_inner(target);
@@ -23,6 +23,14 @@ pub fn find_all_assignments(expr: &Spanned<Expr>) -> Vec<Spanned<String>> {
                 }
                 Pattern::Value(_) => vec![],
             }
+        }
+
+        fn resolve_tmp_loop_vars<'src>(loop_expr: &Spanned<Expr<'src>>) -> Vec<Spanned<String>> {
+            let vars = make_loop_vars(loop_expr.span());
+            vec![
+                Spanned(vars.stack_ptr_var, loop_expr.span()),
+                Spanned(vars.iterator_var, loop_expr.span()),
+            ]
         }
 
         match &expr.0 {
@@ -54,20 +62,23 @@ pub fn find_all_assignments(expr: &Spanned<Expr>) -> Vec<Spanned<String>> {
             }
 
             Expr::While(cond, body) => {
-                let mut res = find_all_assignments_inner(cond);
+                let mut res = resolve_tmp_loop_vars(expr);
+                res.extend(find_all_assignments_inner(cond));
                 res.extend(find_all_assignments_inner(body));
                 res
             }
 
             Expr::For(loop_var, iterable, body) => {
-                let mut res = resolve_assignment_target(loop_var);
+                let mut res = resolve_tmp_loop_vars(expr);
+                res.extend(resolve_assignment_target(loop_var));
                 res.extend(find_all_assignments_inner(iterable));
                 res.extend(find_all_assignments_inner(body));
                 res
             }
 
             Expr::ListComprehension(body, loop_var, iterable) => {
-                let mut res = resolve_assignment_target(loop_var);
+                let mut res = resolve_tmp_loop_vars(expr);
+                res.extend(resolve_assignment_target(loop_var));
                 res.extend(find_all_assignments_inner(iterable));
                 res.extend(find_all_assignments_inner(body));
                 res
@@ -123,7 +134,7 @@ pub fn find_all_assignments(expr: &Spanned<Expr>) -> Vec<Spanned<String>> {
     let mut seen = HashSet::new();
     find_all_assignments_inner(expr)
         .into_iter()
-        .filter(|Spanned(name, _)| seen.insert(*name))
+        .filter(|Spanned(name, _)| seen.insert(name.clone()))
         .map(|Spanned(name, span)| Spanned(name.to_string(), span))
         .collect()
 }

--- a/linefeed/tests/linefeed/advent_of_code_2020/day07.lf
+++ b/linefeed/tests/linefeed/advent_of_code_2020/day07.lf
@@ -15,7 +15,7 @@ fn reach(color, reachable) {
 };
 
 fn count(c) {
-  sum([num * count(child) for num, child in fwd[c]]) + 1
+  1 + sum([num * count(child) for num, child in fwd[c]])
 };
 
 reach("shiny gold", (reachable = set()));

--- a/linefeed/tests/linefeed/list_comprehensions.rs
+++ b/linefeed/tests/linefeed/list_comprehensions.rs
@@ -32,3 +32,17 @@ eval_and_assert!(
     equals("[3, 7, 11]"),
     empty()
 );
+
+// This test is here to cover a (fixed) issue where the list comprehension would create temporary
+// variables that would be stored relative to the the base pointer, but this would overwrite values
+// currently on the stack (e.g. the 5 in the test below). If the 5 was *after* the list
+// comprehension, there would be no issue.
+eval_and_assert!(
+    list_comprehension_doesnt_overwrite_stack_entry,
+    indoc::indoc! {r#"
+        a = 5 + sum([i for i in 1..=1]);
+        print(a);
+    "#},
+    equals("6"),
+    empty()
+);

--- a/linefeed/tests/linefeed/map_with_default.rs
+++ b/linefeed/tests/linefeed/map_with_default.rs
@@ -8,7 +8,7 @@ use indoc::indoc;
 eval_and_assert!(
     map_with_default_works,
     indoc! {r#"
-        m = default_map(42);
+        m = defaultmap(42);
         m["b"] = 100;
         print(m["a"], m["b"]);
     "#},


### PR DESCRIPTION
Loops would create temporary variables on the stack, relative to the base pointer and the number of stack-allocated variables. However, this would break if any temporary value was on the stack.

For example, `5 + sum([i for i in 1..=1])` would place `5` on the stack, but the temporary variables for the list comprehension would take over the stack entry containing `5`. This would erase data from the stack and crash the program later.

To fix this, I unify the way that stack variables are allocated. Previously, I had already introduced logic to preallocate standard variables at the beginning of each function invocation. Only the temporary loop variables still used on-demand stack allocation, so I migrated those to the existing preallocation scheme instead.