### PR TITLE
Add auto-memoized functions

### DIFF
--- a/linefeed-lsp/src/semantic_tokens.rs
+++ b/linefeed-lsp/src/semantic_tokens.rs
@@ -175,6 +175,7 @@ pub fn token_to_semantic_type(token: &Token) -> Option<u32> {
         | Token::Break
         | Token::Continue
         | Token::Match
+        | Token::Memoized
         | Token::Null
         | Token::Bool(_) => Some(TOKEN_TYPE_KEYWORD),
 

--- a/linefeed/src/compiler.rs
+++ b/linefeed/src/compiler.rs
@@ -162,6 +162,7 @@ impl Compiler {
                 let val = IrValue::Function(RuntimeFunction {
                     location: func_label,
                     arity: func.args.len(),
+                    is_memoized: func.is_memoized,
                 });
 
                 let program = Program::new()

--- a/linefeed/src/grammar/ast.rs
+++ b/linefeed/src/grammar/ast.rs
@@ -98,6 +98,7 @@ pub enum UnaryOp {
 pub struct Func<'src> {
     pub args: Vec<&'src str>,
     pub body: Rc<Spanned<Expr<'src>>>,
+    pub is_memoized: bool,
 }
 
 impl PartialEq for Func<'_> {

--- a/linefeed/src/grammar/lexer.rs
+++ b/linefeed/src/grammar/lexer.rs
@@ -29,6 +29,7 @@ pub enum Token<'src> {
     Break,
     Continue,
     Match,
+    Memoized,
     RangeExclusive,
     RangeInclusive,
 }
@@ -60,6 +61,7 @@ impl fmt::Display for Token<'_> {
             Token::Break => write!(f, "break"),
             Token::Continue => write!(f, "continue"),
             Token::Match => write!(f, "match"),
+            Token::Memoized => write!(f, "memoized"),
             Token::RangeExclusive => write!(f, ".."),
             Token::RangeInclusive => write!(f, "..="),
         }
@@ -136,6 +138,7 @@ pub fn lexer<'src>(
         "break" => Token::Break,
         "continue" => Token::Continue,
         "match" => Token::Match,
+        "memoized" => Token::Memoized,
         _ => Token::Ident(ident),
     });
 

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -245,6 +245,7 @@ impl Bytecode {
             IrValue::Function(func) => RuntimeValue::Function(Rc::new(RuntimeFunction {
                 location: label_mapper.get(func.location)?,
                 arity: func.arity,
+                is_memoized: func.is_memoized,
             })),
             IrValue::Regex(s, modifiers) => {
                 let regex = RuntimeRegex::compile(&s, modifiers)

--- a/linefeed/src/vm/runtime_value/function.rs
+++ b/linefeed/src/vm/runtime_value/function.rs
@@ -1,6 +1,15 @@
+use crate::vm::runtime_value::RuntimeValue;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RuntimeFunction<L = usize> {
     pub arity: usize,
     pub location: L,
+    pub is_memoized: bool,
     // TODO: Support default arguments
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MemoizationKey {
+    pub func_location: usize,
+    pub args: Vec<RuntimeValue>,
 }

--- a/linefeed/src/vm/runtime_value/map.rs
+++ b/linefeed/src/vm/runtime_value/map.rs
@@ -118,7 +118,7 @@ impl PartialEq for RuntimeMap {
         let a = self.borrow();
         let b = other.borrow();
 
-        a.len() == b.len() && a.iter().zip(b.iter()).all(|(a, b)| a == b)
+        a.len() == b.len() && a.iter().all(|(key, val)| b.get(key) == Some(val))
     }
 }
 

--- a/linefeed/src/vm/runtime_value/set.rs
+++ b/linefeed/src/vm/runtime_value/set.rs
@@ -62,7 +62,7 @@ impl PartialEq for RuntimeSet {
         let a = self.0.borrow();
         let b = other.0.borrow();
 
-        a.len() == b.len() && a.iter().zip(b.iter()).all(|(a, b)| a == b)
+        a.len() == b.len() && a.iter().all(|item| b.contains(item))
     }
 }
 

--- a/linefeed/tests/linefeed/advent_of_code_2020/day10.lf
+++ b/linefeed/tests/linefeed/advent_of_code_2020/day10.lf
@@ -27,4 +27,4 @@ memoized fn dfs(node) {
 part2 = dfs(0);
 
 print("Part 1:", part1);
-print("Part 1:", part2);
+print("Part 2:", part2);

--- a/linefeed/tests/linefeed/advent_of_code_2020/day10.lf
+++ b/linefeed/tests/linefeed/advent_of_code_2020/day10.lf
@@ -19,12 +19,9 @@ for a in adapters {
   };
 };
 
-# TODO: Add memoized decorator
-memo = {};
-fn dfs(node) {
-  return memo[node] if node in memo;
+memoized fn dfs(node) {
   return 1 if node == adapters[-1];
-  memo[node] = sum([dfs(neighbor) for neighbor in graph[node]])
+  sum([dfs(neighbor) for neighbor in graph[node]])
 };
 
 part2 = dfs(0);

--- a/linefeed/tests/linefeed/main.rs
+++ b/linefeed/tests/linefeed/main.rs
@@ -17,6 +17,7 @@ mod map;
 mod map_with_default;
 mod match_;
 mod math;
+mod memoized;
 mod method;
 mod postfix_control_flow;
 mod print;

--- a/linefeed/tests/linefeed/memoized.rs
+++ b/linefeed/tests/linefeed/memoized.rs
@@ -1,4 +1,7 @@
-use crate::helpers::{eval_and_assert, output::{empty, equals}};
+use crate::helpers::{
+    eval_and_assert,
+    output::{empty, equals},
+};
 use indoc::indoc;
 
 // Basic memoization - side effects only happen once

--- a/linefeed/tests/linefeed/memoized.rs
+++ b/linefeed/tests/linefeed/memoized.rs
@@ -1,0 +1,601 @@
+use crate::helpers::{eval_and_assert, output::{empty, equals}};
+use indoc::indoc;
+
+// Basic memoization - side effects only happen once
+eval_and_assert!(
+    memoized_basic_caching,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn expensive(n) {
+            call_count = call_count + 1;
+            n * 2
+        };
+
+        print(expensive(5));
+        print(expensive(5));
+        print(expensive(5));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        10
+        10
+        10
+        Total calls: 1
+    "#}),
+    empty()
+);
+
+// Different arguments are cached separately
+eval_and_assert!(
+    memoized_different_args,
+    indoc! {r#"
+        memoized fn square(n) {
+            print("Computing square of", n);
+            n * n
+        };
+
+        print(square(2));
+        print(square(3));
+        print(square(2));
+        print(square(3));
+        print(square(4));
+    "#},
+    equals(indoc! {r#"
+        Computing square of 2
+        4
+        Computing square of 3
+        9
+        4
+        9
+        Computing square of 4
+        16
+    "#}),
+    empty()
+);
+
+// Multiple parameters - cache key includes all params
+eval_and_assert!(
+    memoized_multiple_params,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn add(a, b) {
+            call_count = call_count + 1;
+            a + b
+        };
+
+        print(add(1, 2));
+        print(add(2, 1));
+        print(add(1, 2));
+        print(add(2, 1));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        3
+        3
+        3
+        3
+        Total calls: 2
+    "#}),
+    empty()
+);
+
+// Recursive memoization - dramatic performance improvement
+eval_and_assert!(
+    memoized_recursive_fibonacci,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn fib(n) {
+            call_count = call_count + 1;
+            if n <= 1 {
+                n
+            } else {
+                fib(n - 1) + fib(n - 2)
+            }
+        };
+
+        print("fib(10) =", fib(10));
+        print("Total calls:", call_count);
+        print("fib(10) again =", fib(10));
+        print("Total calls after second invocation:", call_count);
+    "#},
+    equals(indoc! {r#"
+        fib(10) = 55
+        Total calls: 11
+        fib(10) again = 55
+        Total calls after second invocation: 11
+    "#}),
+    empty()
+);
+
+// Zero parameters - cache the single result
+eval_and_assert!(
+    memoized_zero_params,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn get_constant() {
+            call_count = call_count + 1;
+            print("Computing constant");
+            42
+        };
+
+        print(get_constant());
+        print(get_constant());
+        print(get_constant());
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        Computing constant
+        42
+        42
+        42
+        Total calls: 1
+    "#}),
+    empty()
+);
+
+// Lists as arguments - value equality
+eval_and_assert!(
+    memoized_with_lists,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn process_list(items) {
+            call_count = call_count + 1;
+            sum(items)
+        };
+
+        print(process_list([1, 2, 3]));
+        print(process_list([1, 2, 3]));
+        print(process_list([1, 2, 4]));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        6
+        6
+        7
+        Total calls: 2
+    "#}),
+    empty()
+);
+
+// Tuples as arguments
+eval_and_assert!(
+    memoized_with_tuples,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn process_tuple(pair) {
+            call_count = call_count + 1;
+            (a, b) = pair;
+            a + b
+        };
+
+        print(process_tuple((1, 2)));
+        print(process_tuple((1, 2)));
+        print(process_tuple((2, 1)));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        3
+        3
+        3
+        Total calls: 2
+    "#}),
+    empty()
+);
+
+// Maps as arguments
+eval_and_assert!(
+    memoized_with_maps,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn process_map(m) {
+            call_count = call_count + 1;
+            m["x"] + m["y"]
+        };
+
+        print(process_map({"x": 1, "y": 2}));
+        print(process_map({"x": 1, "y": 2}));
+        print(process_map({"x": 2, "y": 2}));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        3
+        3
+        4
+        Total calls: 2
+    "#}),
+    empty()
+);
+
+// Sets as arguments
+eval_and_assert!(
+    memoized_with_sets,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn process_set(s) {
+            call_count = call_count + 1;
+            len(s)
+        };
+
+        print(process_set({1, 2, 3}));
+        print(process_set({1, 2, 3}));
+        print(process_set({1, 2, 3, 4}));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        3
+        3
+        4
+        Total calls: 2
+    "#}),
+    empty()
+);
+
+// Memoized function inside if block (any scope)
+eval_and_assert!(
+    memoized_in_if_block,
+    indoc! {r#"
+        call_count = 0;
+
+        if true {
+            memoized fn foo(x) {
+                call_count = call_count + 1;
+                x * 2
+            };
+
+            print(foo(5));
+            print(foo(5));
+            print(foo(5));
+        };
+
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        10
+        10
+        10
+        Total calls: 1
+    "#}),
+    empty()
+);
+
+// Memoized function inside while block
+eval_and_assert!(
+    memoized_in_while_block,
+    indoc! {r#"
+        call_count = 0;
+        i = 0;
+
+        while i < 1 {
+            memoized fn double(x) {
+                call_count = call_count + 1;
+                x * 2
+            };
+
+            print(double(3));
+            print(double(3));
+            i = i + 1;
+        };
+
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        6
+        6
+        Total calls: 1
+    "#}),
+    empty()
+);
+
+// Memoized function inside another function
+eval_and_assert!(
+    memoized_nested_in_function,
+    indoc! {r#"
+        call_count = 0;
+
+        fn outer() {
+            memoized fn inner(x) {
+                call_count = call_count + 1;
+                x + 10
+            };
+
+            print(inner(5));
+            print(inner(5));
+            print(inner(7));
+            print(inner(5));
+        };
+
+        outer();
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        15
+        15
+        17
+        15
+        Total calls: 2
+    "#}),
+    empty()
+);
+
+// Memoized with mixed types
+eval_and_assert!(
+    memoized_mixed_types,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn process(a, b, c) {
+            call_count = call_count + 1;
+            print("Computing:", a, b, c);
+            a + len(b) + c
+        };
+
+        print(process(1, [1, 2], 3));
+        print(process(1, [1, 2], 3));
+        print(process(1, [1, 2, 3], 3));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        Computing: 1 [1, 2] 3
+        6
+        6
+        Computing: 1 [1, 2, 3] 3
+        7
+        Total calls: 2
+    "#}),
+    empty()
+);
+
+// Memoized with null values
+eval_and_assert!(
+    memoized_with_null,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn handle_null(x) {
+            call_count = call_count + 1;
+            if x == null {
+                "got null"
+            } else {
+                x
+            }
+        };
+
+        print(handle_null(null));
+        print(handle_null(null));
+        print(handle_null(5));
+        print(handle_null(null));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        got null
+        got null
+        5
+        got null
+        Total calls: 2
+    "#}),
+    empty()
+);
+
+// Memoized with empty collections
+eval_and_assert!(
+    memoized_empty_collections,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn process_empty(lst) {
+            call_count = call_count + 1;
+            len(lst)
+        };
+
+        print(process_empty([]));
+        print(process_empty([]));
+        print(process_empty([1]));
+        print(process_empty([]));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        0
+        0
+        1
+        0
+        Total calls: 2
+    "#}),
+    empty()
+);
+
+// Memoized function that returns functions
+eval_and_assert!(
+    memoized_returning_function,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn make_adder(n) {
+            call_count = call_count + 1;
+            print("Creating adder for", n);
+            fn(x) n + x
+        };
+
+        add5 = make_adder(5);
+        add5_again = make_adder(5);
+        add10 = make_adder(10);
+
+        print(add5(3));
+        print(add5_again(7));
+        print(add10(3));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        Creating adder for 5
+        Creating adder for 10
+        8
+        12
+        13
+        Total calls: 2
+    "#}),
+    empty()
+);
+
+// Multiple memoized functions interacting
+eval_and_assert!(
+    multiple_memoized_functions,
+    indoc! {r#"
+        count_a = 0;
+        count_b = 0;
+
+        memoized fn func_a(x) {
+            count_a = count_a + 1;
+            x * 2
+        };
+
+        memoized fn func_b(x) {
+            count_b = count_b + 1;
+            func_a(x) + 1
+        };
+
+        print(func_b(5));
+        print(func_b(5));
+        print(func_a(5));
+        print(func_b(3));
+        print(func_b(5));
+
+        print("func_a calls:", count_a);
+        print("func_b calls:", count_b);
+    "#},
+    equals(indoc! {r#"
+        11
+        11
+        10
+        7
+        11
+        func_a calls: 2
+        func_b calls: 2
+    "#}),
+    empty()
+);
+
+// Memoized with boolean arguments
+eval_and_assert!(
+    memoized_with_booleans,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn process_bool(flag) {
+            call_count = call_count + 1;
+            if flag {
+                "yes"
+            } else {
+                "no"
+            }
+        };
+
+        print(process_bool(true));
+        print(process_bool(false));
+        print(process_bool(true));
+        print(process_bool(false));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        yes
+        no
+        yes
+        no
+        Total calls: 2
+    "#}),
+    empty()
+);
+
+// Memoized with string arguments
+eval_and_assert!(
+    memoized_with_strings,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn greet(name) {
+            call_count = call_count + 1;
+            "Hello, " + name
+        };
+
+        print(greet("Alice"));
+        print(greet("Bob"));
+        print(greet("Alice"));
+        print(greet("Bob"));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        Hello, Alice
+        Hello, Bob
+        Hello, Alice
+        Hello, Bob
+        Total calls: 2
+    "#}),
+    empty()
+);
+
+// Memoized with large fibonacci to demonstrate performance
+eval_and_assert!(
+    memoized_large_fibonacci,
+    indoc! {r#"
+        call_count = 0;
+
+        memoized fn fib(n) {
+            call_count = call_count + 1;
+            if n <= 1 {
+                n
+            } else {
+                fib(n - 1) + fib(n - 2)
+            }
+        };
+
+        result = fib(20);
+        print("fib(20) =", result);
+        print("Total calls:", call_count);
+
+        result2 = fib(15);
+        print("fib(15) =", result2);
+        print("Total calls after fib(15):", call_count);
+    "#},
+    equals(indoc! {r#"
+        fib(20) = 6765
+        Total calls: 21
+        fib(15) = 610
+        Total calls after fib(15): 21
+    "#}),
+    empty()
+);
+
+// Memoized function with captured variables (closure behavior)
+eval_and_assert!(
+    memoized_with_closure_behavior,
+    indoc! {r#"
+        multiplier = 10;
+        call_count = 0;
+
+        memoized fn compute(x) {
+            call_count = call_count + 1;
+            x * multiplier
+        };
+
+        print(compute(5));
+        print(compute(5));
+
+        multiplier = 20;
+
+        print(compute(5));
+        print("Total calls:", call_count);
+    "#},
+    equals(indoc! {r#"
+        50
+        50
+        50
+        Total calls: 1
+    "#}),
+    empty()
+);

--- a/linefeed/tests/linefeed/memoized.rs
+++ b/linefeed/tests/linefeed/memoized.rs
@@ -202,9 +202,9 @@ eval_and_assert!(
             m["x"] + m["y"]
         };
 
-        print(process_map({"x": 1, "y": 2}));
-        print(process_map({"x": 1, "y": 2}));
-        print(process_map({"x": 2, "y": 2}));
+        print(process_map(map = {"x": 1, "y": 2}));
+        print(process_map(map = {"x": 1, "y": 2}));
+        print(process_map(map = {"x": 2, "y": 2}));
         print("Total calls:", call_count);
     "#},
     equals(indoc! {r#"
@@ -224,12 +224,12 @@ eval_and_assert!(
 
         memoized fn process_set(s) {
             call_count = call_count + 1;
-            len(s)
+            s.len()
         };
 
-        print(process_set({1, 2, 3}));
-        print(process_set({1, 2, 3}));
-        print(process_set({1, 2, 3, 4}));
+        print(process_set(set([1, 2, 3])));
+        print(process_set(set([1, 2, 3])));
+        print(process_set(set([1, 2, 3, 4])));
         print("Total calls:", call_count);
     "#},
     equals(indoc! {r#"
@@ -337,7 +337,7 @@ eval_and_assert!(
         memoized fn process(a, b, c) {
             call_count = call_count + 1;
             print("Computing:", a, b, c);
-            a + len(b) + c
+            a + b.len() + c
         };
 
         print(process(1, [1, 2], 3));
@@ -395,7 +395,7 @@ eval_and_assert!(
 
         memoized fn process_empty(lst) {
             call_count = call_count + 1;
-            len(lst)
+            lst.len()
         };
 
         print(process_empty([]));
@@ -409,38 +409,6 @@ eval_and_assert!(
         0
         1
         0
-        Total calls: 2
-    "#}),
-    empty()
-);
-
-// Memoized function that returns functions
-eval_and_assert!(
-    memoized_returning_function,
-    indoc! {r#"
-        call_count = 0;
-
-        memoized fn make_adder(n) {
-            call_count = call_count + 1;
-            print("Creating adder for", n);
-            fn(x) n + x
-        };
-
-        add5 = make_adder(5);
-        add5_again = make_adder(5);
-        add10 = make_adder(10);
-
-        print(add5(3));
-        print(add5_again(7));
-        print(add10(3));
-        print("Total calls:", call_count);
-    "#},
-    equals(indoc! {r#"
-        Creating adder for 5
-        Creating adder for 10
-        8
-        12
-        13
         Total calls: 2
     "#}),
     empty()


### PR DESCRIPTION
Adds a memoized keyword that memoizes function calls, returning cached results if a function is called multiple times with the same arguments.

**Before, with manual memoization:**
```
memo = {};
fn dfs(node) {
  return memo[node] if node in memo;
  return 1 if node == adapters[-1];
  memo[node] = sum([dfs(neighbor) for neighbor in graph[node]])
};
```

**After, with `memoized`:**
```
memoized fn dfs(node) {
  return 1 if node == adapters[-1];
  sum([dfs(neighbor) for neighbor in graph[node]])
};
```

(fret not, the actual change is only ~60 LoC - the tests just take up 572 LoC of this PR)