### PR TITLE
Add mechanism to call user functions

### DIFF
--- a/linefeed/src/compiler/method.rs
+++ b/linefeed/src/compiler/method.rs
@@ -54,7 +54,7 @@ impl Method {
             Self::IsMatch => 1..=1,
             Self::Join => 0..=1,
             Self::Contains => 1..=1,
-            Self::Sort => 0..=0,
+            Self::Sort => 0..=1,
             Self::Enumerate => 0..=0,
         }
     }

--- a/linefeed/src/lib.rs
+++ b/linefeed/src/lib.rs
@@ -61,12 +61,15 @@ pub fn run_with_handles(
     };
     let compile_time = Instant::now().duration_since(compile_start);
 
-    program.disassemble(src.as_ref());
+    // program.disassemble(src.as_ref());
 
     let run_start = Instant::now();
 
-    let mut bytecode_interpreter =
-        BytecodeInterpreter::new(program).with_handles(&mut stdin, &mut stdout, &mut stderr);
+    let mut bytecode_interpreter = BytecodeInterpreter::new(program).with_handles(
+        Box::new(&mut stdin),
+        Box::new(&mut stdout),
+        Box::new(&mut stderr),
+    );
 
     if let Err((span, err)) = bytecode_interpreter.run() {
         return pretty_print_errors(stderr, src, vec![Rich::<RuntimeError>::custom(span, err)]);

--- a/linefeed/src/lib.rs
+++ b/linefeed/src/lib.rs
@@ -72,7 +72,8 @@ pub fn run_with_handles(
     );
 
     if let Err((span, err)) = bytecode_interpreter.run() {
-        return pretty_print_errors(io::stderr(), src, vec![Rich::<RuntimeError>::custom(span, err)]);
+        let stderr = std::mem::replace(&mut bytecode_interpreter.stderr, Box::new(io::sink()));
+        return pretty_print_errors(stderr, src, vec![Rich::<RuntimeError>::custom(span, err)]);
     }
 
     let run_time = Instant::now().duration_since(run_start);

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -151,296 +151,305 @@ where
             #[cfg(feature = "debug-vm")]
             self.dbg_print();
 
-            let instr = &self.program.instructions[self.pc];
-            self.pc += 1;
-            self.instructions_executed += 1;
-
-            match instr {
-                Bytecode::Stop => break Ok(()),
-
-                Bytecode::ConstantInt(i) => {
-                    self.push_stack(RuntimeValue::Int(*i));
-                }
-
-                Bytecode::Value(val) => {
-                    // Perform a "deep" clone here. Otherwise, the same, shared value is inserted onto the
-                    // stack. For things with mutable access, this is BAD. Assign list repeatedly to a
-                    // variable? Same list is shared, it's not a new list. Value is no longer referenced on
-                    // the stack? Too bad, it's still in the program instructions, so it'll keep living.
-                    self.push_stack(val.deep_clone());
-                }
-
-                Bytecode::Add => binary_op!(self, add),
-                Bytecode::Sub => binary_op!(self, sub),
-                Bytecode::Mul => binary_op!(self, mul),
-                Bytecode::Div => binary_op!(self, div),
-                Bytecode::DivFloor => binary_op!(self, div_floor),
-                Bytecode::Mod => binary_op!(self, modulo),
-                Bytecode::Pow => binary_op!(self, pow),
-                Bytecode::Eq => binary_op!(self, eq_bool),
-                Bytecode::NotEq => binary_op!(self, not_eq_bool),
-                Bytecode::Less => binary_op!(self, less_than),
-                Bytecode::LessEq => binary_op!(self, less_than_or_eq),
-                Bytecode::Greater => binary_op!(self, greater_than),
-                Bytecode::GreaterEq => binary_op!(self, greater_than_or_eq),
-                Bytecode::Range => binary_op!(self, range),
-                Bytecode::Xor => binary_op!(self, xor),
-                Bytecode::BitwiseAnd => binary_op!(self, bitwise_and),
-
-                Bytecode::Not => {
-                    let val = self.pop_stack()?;
-                    self.push_stack(RuntimeValue::Bool(!val.bool()));
-                }
-
-                Bytecode::Load => {
-                    let addr = self.pop_stack()?.address()?;
-                    self.push_stack(self.get(addr)?.clone());
-                }
-
-                Bytecode::Store => {
-                    let addr = self.pop_stack()?.address()?;
-                    let val = self.peek_stack()?.clone();
-                    self.set(addr, val)?;
-                }
-
-                Bytecode::Pop => {
-                    self.pop_stack()?;
-                }
-
-                Bytecode::RemoveIndex => {
-                    let index = self.pop_stack()?.address()?;
-                    debug_assert!(index < self.stack.len());
-                    self.stack.remove(index);
-                }
-
-                Bytecode::Swap => {
-                    self.swap();
-                }
-
-                Bytecode::Dup => {
-                    let val = self.peek_stack()?.clone();
-                    self.push_stack(val);
-                }
-
-                Bytecode::GetStackPtr => {
-                    self.push_stack(RuntimeValue::Int((self.stack.len() - 1) as isize));
-                }
-
-                Bytecode::SetStackPtr => {
-                    let new_ptr = self.pop_stack()?.address()?;
-                    self.stack.truncate(new_ptr + 1);
-                }
-
-                Bytecode::SetRegister(reg) => {
-                    let reg = *reg;
-                    self.registers[reg] = self.pop_stack()?.int()?;
-                }
-
-                Bytecode::GetRegister(reg) => {
-                    let reg = *reg;
-                    self.push_stack(RuntimeValue::Int(self.registers[reg]));
-                }
-
-                Bytecode::IfFalse(idx) => {
-                    let idx = *idx;
-                    let val = self.pop_stack()?;
-                    if !val.bool() {
-                        self.pc = idx;
-                    }
-                }
-
-                Bytecode::IfTrue(idx) => {
-                    let idx = *idx;
-                    let val = self.pop_stack()?;
-                    if val.bool() {
-                        self.pc = idx;
-                    }
-                }
-
-                Bytecode::Goto(idx) => {
-                    self.pc = *idx;
-                }
-
-                Bytecode::GetBasePtr => {
-                    self.push_stack(RuntimeValue::Int(self.bp as isize));
-                }
-
-                Bytecode::Call(num_args) => {
-                    let num_args = *num_args;
-
-                    let func_index = self.stack.len() - 1 - num_args;
-                    let func = match &self.stack[func_index] {
-                        RuntimeValue::Function(func) => func,
-                        val => {
-                            break Err(RuntimeError::TypeMismatch(format!(
-                                "Cannot call type {} as a function",
-                                val.kind_str()
-                            )));
-                        }
-                    };
-
-                    if func.arity != num_args {
-                        break Err(RuntimeError::TypeMismatch(format!(
-                            "Expected {} arguments, got {}",
-                            func.arity, num_args
-                        )));
-                    }
-
-                    let func_location = func.location;
-
-                    if func.is_memoized {
-                        let args = self.stack[self.stack.len() - num_args..].to_vec();
-
-                        let memo_key = MemoizationKey {
-                            func_location,
-                            args,
-                        };
-
-                        match self.memoized_functions.get(&memo_key) {
-                            Some(cached_result) => {
-                                self.stack.truncate(func_index);
-                                self.push_stack(cached_result.clone());
-                                continue;
-                            }
-                            None => {
-                                self.ongoing_memoizations.insert(func_index, memo_key);
-                            }
-                        }
-                    }
-
-                    // Store pc and bp (2 slots), then start new stack frame after that
-                    let new_bp = func_index + 2;
-
-                    // First slot is the return address; pop function instance and insert return address
-                    self.stack[new_bp - 2] = RuntimeValue::Int(self.pc as isize);
-                    // Second slot is the old base pointer
-                    self.stack
-                        .insert(new_bp - 1, RuntimeValue::Int(self.bp as isize));
-
-                    // And then set the new base pointer and jump to the function
-                    self.bp = new_bp;
-                    self.pc = func_location;
-                }
-
-                Bytecode::Return => {
-                    let return_val = self.pop_stack()?;
-                    let frame_index = self.bp - 2;
-
-                    let return_addr = self.stack[self.bp - 2].address()?;
-                    self.bp = self.stack[self.bp - 1].address()?;
-                    self.pc = return_addr;
-
-                    if let Some(memo_key) = self.ongoing_memoizations.remove(&frame_index) {
-                        self.memoized_functions.insert(memo_key, return_val.clone());
-                    }
-
-                    self.stack.truncate(frame_index);
-                    self.push_stack(return_val);
-                }
-
-                Bytecode::Append => {
-                    let val = self.pop_stack()?;
-                    let into = self.peek_stack_mut()?;
-                    into.append(val)?;
-                }
-
-                Bytecode::Index => {
-                    let index = self.pop_stack()?;
-                    let into = self.peek_stack_mut()?;
-                    let value = into.index(&index)?;
-                    *into = value;
-                }
-
-                Bytecode::SetIndex => {
-                    let value = self.pop_stack()?;
-                    let index = self.pop_stack()?;
-                    let into = self.peek_stack_mut()?;
-                    into.set_index(&index, value)?;
-                }
-
-                Bytecode::NextIter => {
-                    let iter = self.pop_stack()?;
-                    let value = iter.next()?;
-                    let has_value = RuntimeValue::Bool(value.is_some());
-
-                    if let Some(value) = value {
-                        self.push_stack(value);
-                    }
-                    self.push_stack(has_value);
-                }
-
-                Bytecode::ToIter => unary_mapper_method!(self, to_iter),
-                Bytecode::ToUpperCase => unary_mapper_method!(self, to_uppercase),
-                Bytecode::ToLowerCase => unary_mapper_method!(self, to_lowercase),
-                Bytecode::Split => binary_op!(self, split),
-                Bytecode::SplitLines => unary_mapper_method!(self, lines),
-                Bytecode::Join(num_args) => method_with_optional_arg!(self, join, *num_args),
-                Bytecode::Length => unary_mapper_method!(self, length),
-                Bytecode::Count => binary_op!(self, count),
-                Bytecode::FindAll => binary_op!(self, find_all),
-                Bytecode::Find => binary_op!(self, find),
-                Bytecode::IsMatch => binary_op!(self, is_match),
-                Bytecode::Contains => binary_op!(self, contains),
-                Bytecode::IsIn => binary_op_swapped!(self, contains),
-                Bytecode::Sort => unary_mapper_method!(self, sort),
-                Bytecode::Enumerate => unary_mapper_method!(self, enumerate),
-
-                Bytecode::ParseInt => stdlib_fn!(self, parse_int),
-                Bytecode::ToList => stdlib_fn!(self, to_list),
-                Bytecode::ToTuple => stdlib_fn!(self, to_tuple),
-                Bytecode::ToMap => stdlib_fn!(self, to_map),
-                Bytecode::MapWithDefault => stdlib_fn!(self, map_with_default),
-                Bytecode::ToSet(num_args) => stdlib_fn_with_optional_arg!(self, to_set, *num_args),
-                Bytecode::ToCounter(num_args) => {
-                    stdlib_fn_with_optional_arg!(self, to_counter, *num_args)
-                }
-                Bytecode::Product => stdlib_fn!(self, mul),
-                Bytecode::Sum => stdlib_fn!(self, sum),
-                Bytecode::AllTrue(num_args) => stdlib_fn!(self, all, *num_args),
-                Bytecode::AnyTrue(num_args) => stdlib_fn!(self, any, *num_args),
-                Bytecode::Max(num_args) => stdlib_fn!(self, max, *num_args),
-                Bytecode::Min(num_args) => stdlib_fn!(self, min, *num_args),
-
-                Bytecode::PrintValue(num_args) => {
-                    let vals = self.pop_args(*num_args)?;
-
-                    let mut last_val = None;
-                    for val in vals {
-                        if last_val.is_some() {
-                            write!(self.stdout, " ").unwrap();
-                        }
-                        write!(self.stdout, "{val}").unwrap();
-
-                        last_val = Some(val);
-                    }
-                    writeln!(self.stdout).unwrap();
-
-                    self.push_stack(last_val.unwrap_or(RuntimeValue::Null));
-                }
-
-                Bytecode::ReprString => {
-                    let val = self.pop_stack()?;
-                    let repr = val.repr_string();
-                    self.push_stack(RuntimeValue::Str(RuntimeString::new(repr)));
-                }
-
-                Bytecode::ReadInput => {
-                    let mut input = String::new();
-                    self.stdin.read_to_string(&mut input).map_err(|e| {
-                        RuntimeError::InternalBug(format!("Failed to read stdin: {e}"))
-                    })?;
-
-                    self.push_stack(RuntimeValue::Str(RuntimeString::new(input)));
-                }
-
-                Bytecode::RuntimeError(err) => break Err(RuntimeError::Plain(err.clone())),
-
-                #[allow(unreachable_patterns)]
-                to_implement => {
-                    break Err(RuntimeError::NotImplemented(to_implement.clone()));
-                }
+            match self.execute_cur_instruction()? {
+                ControlFlow::Continue => {}
+                ControlFlow::Stop => break Ok(()),
             }
         }
+    }
+
+    fn execute_cur_instruction(&mut self) -> Result<ControlFlow, RuntimeError> {
+        let instr = &self.program.instructions[self.pc];
+        self.pc += 1;
+        self.instructions_executed += 1;
+
+        match instr {
+            Bytecode::Stop => return Ok(ControlFlow::Stop),
+
+            Bytecode::ConstantInt(i) => {
+                self.push_stack(RuntimeValue::Int(*i));
+            }
+
+            Bytecode::Value(val) => {
+                // Perform a "deep" clone here. Otherwise, the same, shared value is inserted onto the
+                // stack. For things with mutable access, this is BAD. Assign list repeatedly to a
+                // variable? Same list is shared, it's not a new list. Value is no longer referenced on
+                // the stack? Too bad, it's still in the program instructions, so it'll keep living.
+                self.push_stack(val.deep_clone());
+            }
+
+            Bytecode::Add => binary_op!(self, add),
+            Bytecode::Sub => binary_op!(self, sub),
+            Bytecode::Mul => binary_op!(self, mul),
+            Bytecode::Div => binary_op!(self, div),
+            Bytecode::DivFloor => binary_op!(self, div_floor),
+            Bytecode::Mod => binary_op!(self, modulo),
+            Bytecode::Pow => binary_op!(self, pow),
+            Bytecode::Eq => binary_op!(self, eq_bool),
+            Bytecode::NotEq => binary_op!(self, not_eq_bool),
+            Bytecode::Less => binary_op!(self, less_than),
+            Bytecode::LessEq => binary_op!(self, less_than_or_eq),
+            Bytecode::Greater => binary_op!(self, greater_than),
+            Bytecode::GreaterEq => binary_op!(self, greater_than_or_eq),
+            Bytecode::Range => binary_op!(self, range),
+            Bytecode::Xor => binary_op!(self, xor),
+            Bytecode::BitwiseAnd => binary_op!(self, bitwise_and),
+
+            Bytecode::Not => {
+                let val = self.pop_stack()?;
+                self.push_stack(RuntimeValue::Bool(!val.bool()));
+            }
+
+            Bytecode::Load => {
+                let addr = self.pop_stack()?.address()?;
+                self.push_stack(self.get(addr)?.clone());
+            }
+
+            Bytecode::Store => {
+                let addr = self.pop_stack()?.address()?;
+                let val = self.peek_stack()?.clone();
+                self.set(addr, val)?;
+            }
+
+            Bytecode::Pop => {
+                self.pop_stack()?;
+            }
+
+            Bytecode::RemoveIndex => {
+                let index = self.pop_stack()?.address()?;
+                debug_assert!(index < self.stack.len());
+                self.stack.remove(index);
+            }
+
+            Bytecode::Swap => {
+                self.swap();
+            }
+
+            Bytecode::Dup => {
+                let val = self.peek_stack()?.clone();
+                self.push_stack(val);
+            }
+
+            Bytecode::GetStackPtr => {
+                self.push_stack(RuntimeValue::Int((self.stack.len() - 1) as isize));
+            }
+
+            Bytecode::SetStackPtr => {
+                let new_ptr = self.pop_stack()?.address()?;
+                self.stack.truncate(new_ptr + 1);
+            }
+
+            Bytecode::SetRegister(reg) => {
+                let reg = *reg;
+                self.registers[reg] = self.pop_stack()?.int()?;
+            }
+
+            Bytecode::GetRegister(reg) => {
+                let reg = *reg;
+                self.push_stack(RuntimeValue::Int(self.registers[reg]));
+            }
+
+            Bytecode::IfFalse(idx) => {
+                let idx = *idx;
+                let val = self.pop_stack()?;
+                if !val.bool() {
+                    self.pc = idx;
+                }
+            }
+
+            Bytecode::IfTrue(idx) => {
+                let idx = *idx;
+                let val = self.pop_stack()?;
+                if val.bool() {
+                    self.pc = idx;
+                }
+            }
+
+            Bytecode::Goto(idx) => {
+                self.pc = *idx;
+            }
+
+            Bytecode::GetBasePtr => {
+                self.push_stack(RuntimeValue::Int(self.bp as isize));
+            }
+
+            Bytecode::Call(num_args) => {
+                let num_args = *num_args;
+
+                let func_index = self.stack.len() - 1 - num_args;
+                let func = match &self.stack[func_index] {
+                    RuntimeValue::Function(func) => func,
+                    val => {
+                        return Err(RuntimeError::TypeMismatch(format!(
+                            "Cannot call type {} as a function",
+                            val.kind_str()
+                        )));
+                    }
+                };
+
+                if func.arity != num_args {
+                    return Err(RuntimeError::TypeMismatch(format!(
+                        "Expected {} arguments, got {}",
+                        func.arity, num_args
+                    )));
+                }
+
+                let func_location = func.location;
+
+                if func.is_memoized {
+                    let args = self.stack[self.stack.len() - num_args..].to_vec();
+
+                    let memo_key = MemoizationKey {
+                        func_location,
+                        args,
+                    };
+
+                    match self.memoized_functions.get(&memo_key) {
+                        Some(cached_result) => {
+                            self.stack.truncate(func_index);
+                            self.push_stack(cached_result.clone());
+                            return Ok(ControlFlow::Continue);
+                        }
+                        None => {
+                            self.ongoing_memoizations.insert(func_index, memo_key);
+                        }
+                    }
+                }
+
+                // Store pc and bp (2 slots), then start new stack frame after that
+                let new_bp = func_index + 2;
+
+                // First slot is the return address; pop function instance and insert return address
+                self.stack[new_bp - 2] = RuntimeValue::Int(self.pc as isize);
+                // Second slot is the old base pointer
+                self.stack
+                    .insert(new_bp - 1, RuntimeValue::Int(self.bp as isize));
+
+                // And then set the new base pointer and jump to the function
+                self.bp = new_bp;
+                self.pc = func_location;
+            }
+
+            Bytecode::Return => {
+                let return_val = self.pop_stack()?;
+                let frame_index = self.bp - 2;
+
+                let return_addr = self.stack[self.bp - 2].address()?;
+                self.bp = self.stack[self.bp - 1].address()?;
+                self.pc = return_addr;
+
+                if let Some(memo_key) = self.ongoing_memoizations.remove(&frame_index) {
+                    self.memoized_functions.insert(memo_key, return_val.clone());
+                }
+
+                self.stack.truncate(frame_index);
+                self.push_stack(return_val);
+            }
+
+            Bytecode::Append => {
+                let val = self.pop_stack()?;
+                let into = self.peek_stack_mut()?;
+                into.append(val)?;
+            }
+
+            Bytecode::Index => {
+                let index = self.pop_stack()?;
+                let into = self.peek_stack_mut()?;
+                let value = into.index(&index)?;
+                *into = value;
+            }
+
+            Bytecode::SetIndex => {
+                let value = self.pop_stack()?;
+                let index = self.pop_stack()?;
+                let into = self.peek_stack_mut()?;
+                into.set_index(&index, value)?;
+            }
+
+            Bytecode::NextIter => {
+                let iter = self.pop_stack()?;
+                let value = iter.next()?;
+                let has_value = RuntimeValue::Bool(value.is_some());
+
+                if let Some(value) = value {
+                    self.push_stack(value);
+                }
+                self.push_stack(has_value);
+            }
+
+            Bytecode::ToIter => unary_mapper_method!(self, to_iter),
+            Bytecode::ToUpperCase => unary_mapper_method!(self, to_uppercase),
+            Bytecode::ToLowerCase => unary_mapper_method!(self, to_lowercase),
+            Bytecode::Split => binary_op!(self, split),
+            Bytecode::SplitLines => unary_mapper_method!(self, lines),
+            Bytecode::Join(num_args) => method_with_optional_arg!(self, join, *num_args),
+            Bytecode::Length => unary_mapper_method!(self, length),
+            Bytecode::Count => binary_op!(self, count),
+            Bytecode::FindAll => binary_op!(self, find_all),
+            Bytecode::Find => binary_op!(self, find),
+            Bytecode::IsMatch => binary_op!(self, is_match),
+            Bytecode::Contains => binary_op!(self, contains),
+            Bytecode::IsIn => binary_op_swapped!(self, contains),
+            Bytecode::Sort => unary_mapper_method!(self, sort),
+            Bytecode::Enumerate => unary_mapper_method!(self, enumerate),
+
+            Bytecode::ParseInt => stdlib_fn!(self, parse_int),
+            Bytecode::ToList => stdlib_fn!(self, to_list),
+            Bytecode::ToTuple => stdlib_fn!(self, to_tuple),
+            Bytecode::ToMap => stdlib_fn!(self, to_map),
+            Bytecode::MapWithDefault => stdlib_fn!(self, map_with_default),
+            Bytecode::ToSet(num_args) => stdlib_fn_with_optional_arg!(self, to_set, *num_args),
+            Bytecode::ToCounter(num_args) => {
+                stdlib_fn_with_optional_arg!(self, to_counter, *num_args)
+            }
+            Bytecode::Product => stdlib_fn!(self, mul),
+            Bytecode::Sum => stdlib_fn!(self, sum),
+            Bytecode::AllTrue(num_args) => stdlib_fn!(self, all, *num_args),
+            Bytecode::AnyTrue(num_args) => stdlib_fn!(self, any, *num_args),
+            Bytecode::Max(num_args) => stdlib_fn!(self, max, *num_args),
+            Bytecode::Min(num_args) => stdlib_fn!(self, min, *num_args),
+
+            Bytecode::PrintValue(num_args) => {
+                let vals = self.pop_args(*num_args)?;
+
+                let mut last_val = None;
+                for val in vals {
+                    if last_val.is_some() {
+                        write!(self.stdout, " ").unwrap();
+                    }
+                    write!(self.stdout, "{val}").unwrap();
+
+                    last_val = Some(val);
+                }
+                writeln!(self.stdout).unwrap();
+
+                self.push_stack(last_val.unwrap_or(RuntimeValue::Null));
+            }
+
+            Bytecode::ReprString => {
+                let val = self.pop_stack()?;
+                let repr = val.repr_string();
+                self.push_stack(RuntimeValue::Str(RuntimeString::new(repr)));
+            }
+
+            Bytecode::ReadInput => {
+                let mut input = String::new();
+                self.stdin
+                    .read_to_string(&mut input)
+                    .map_err(|e| RuntimeError::InternalBug(format!("Failed to read stdin: {e}")))?;
+
+                self.push_stack(RuntimeValue::Str(RuntimeString::new(input)));
+            }
+
+            Bytecode::RuntimeError(err) => return Err(RuntimeError::Plain(err.clone())),
+
+            #[allow(unreachable_patterns)]
+            to_implement => {
+                return Err(RuntimeError::NotImplemented(to_implement.clone()));
+            }
+        }
+
+        Ok(ControlFlow::Continue)
     }
 
     pub fn pop_stack(&mut self) -> Result<RuntimeValue, RuntimeError> {
@@ -563,4 +572,9 @@ where
         }
         eprintln!();
     }
+}
+
+enum ControlFlow {
+    Continue,
+    Stop,
 }

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -530,7 +530,7 @@ where
         let saved_bp = self.bp;
         let stack_base = self.stack.len();
 
-        self.bp = stack_base - 1;
+        self.bp = stack_base;
         self.pc = func.location;
         self.stack.extend(args);
 

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -394,7 +394,15 @@ where
             Bytecode::IsMatch => binary_op!(self, is_match),
             Bytecode::Contains => binary_op!(self, contains),
             Bytecode::IsIn => binary_op_swapped!(self, contains),
-            Bytecode::Sort => unary_mapper_method!(self, sort),
+
+            Bytecode::Sort(num_args) => {
+                let mut args = self.pop_args((*num_args))?;
+                let arg = args.pop();
+                let target = self.pop_stack()?;
+                let res = target.sort(self, arg)?;
+                self.push_stack(res);
+            }
+
             Bytecode::Enumerate => unary_mapper_method!(self, enumerate),
 
             Bytecode::ParseInt => stdlib_fn!(self, parse_int),

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -152,9 +152,6 @@ where
 
     fn run_inner(&mut self) -> Result<(), RuntimeError> {
         loop {
-            #[cfg(feature = "debug-vm")]
-            self.dbg_print();
-
             match self.execute_cur_instruction()? {
                 ControlFlow::Continue => {}
                 ControlFlow::Stop => break Ok(()),
@@ -163,6 +160,9 @@ where
     }
 
     fn execute_cur_instruction(&mut self) -> Result<ControlFlow, RuntimeError> {
+        #[cfg(feature = "debug-vm")]
+        self.dbg_print();
+
         let instr = &self.program.instructions[self.pc];
         self.pc += 1;
         self.instructions_executed += 1;
@@ -518,6 +518,18 @@ where
         func: &RuntimeFunction,
         args: Vec<RuntimeValue>,
     ) -> Result<RuntimeValue, RuntimeError> {
+        #[cfg(feature = "debug-vm")]
+        eprintln!(
+            "{}\n",
+            format!(
+                "Calling user function <function@{}> with {} args",
+                func.location,
+                args.len()
+            )
+            .yellow()
+            .italic()
+        );
+
         if func.arity != args.len() {
             return Err(RuntimeError::TypeMismatch(format!(
                 "Expected {} arguments, got {}",
@@ -544,6 +556,15 @@ where
             }
 
             self.execute_cur_instruction()?;
+        }
+
+        #[cfg(feature = "debug-vm")]
+        {
+            self.dbg_print();
+            eprintln!(
+                "{}\n",
+                format!("Ending user function call",).yellow().italic()
+            );
         }
 
         let result = self.pop_stack()?;

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -102,7 +102,7 @@ pub enum Bytecode {
     Find,
     IsMatch,
     Contains,
-    Sort,
+    Sort(usize),
     Enumerate,
 }
 
@@ -188,7 +188,7 @@ impl Bytecode {
                 Method::Find => Bytecode::Find,
                 Method::IsMatch => Bytecode::IsMatch,
                 Method::Contains => Bytecode::Contains,
-                Method::Sort => Bytecode::Sort,
+                Method::Sort => Bytecode::Sort(num_args),
                 Method::Enumerate => Bytecode::Enumerate,
             },
         };

--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -17,7 +17,7 @@ use crate::{
             string::RuntimeString,
             tuple::RuntimeTuple,
         },
-        RuntimeError,
+        BytecodeInterpreter, RuntimeError,
     },
 };
 
@@ -333,10 +333,28 @@ impl RuntimeValue {
         })
     }
 
-    pub fn sort(&self) -> Result<Self, RuntimeError> {
+    pub fn sort<I, O, E>(
+        &self,
+        vm: &mut BytecodeInterpreter<I, O, E>,
+        key_fn: Option<RuntimeValue>,
+    ) -> Result<Self, RuntimeError>
+    where
+        I: std::io::Read,
+        O: std::io::Write,
+        E: std::io::Write,
+    {
         match self {
             RuntimeValue::List(list) => {
-                list.sort();
+                match key_fn {
+                    Some(RuntimeValue::Function(func)) => list.sort_by_key(vm, func.as_ref())?,
+                    None => list.sort(),
+                    Some(_) => {
+                        return Err(RuntimeError::TypeMismatch(
+                            "Sort key must be a function".to_string(),
+                        ))
+                    }
+                };
+
                 Ok(RuntimeValue::List(list.clone()))
             }
             _ => Err(RuntimeError::invalid_method_for_type(Method::Sort, self)),

--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -333,16 +333,11 @@ impl RuntimeValue {
         })
     }
 
-    pub fn sort<I, O, E>(
+    pub fn sort(
         &self,
-        vm: &mut BytecodeInterpreter<I, O, E>,
+        vm: &mut BytecodeInterpreter,
         key_fn: Option<RuntimeValue>,
-    ) -> Result<Self, RuntimeError>
-    where
-        I: std::io::Read,
-        O: std::io::Write,
-        E: std::io::Write,
-    {
+    ) -> Result<Self, RuntimeError> {
         match self {
             RuntimeValue::List(list) => {
                 match key_fn {

--- a/linefeed/src/vm/runtime_value/list.rs
+++ b/linefeed/src/vm/runtime_value/list.rs
@@ -10,7 +10,6 @@ use crate::vm::{
         number::RuntimeNumber,
         operations::LfAppend,
         range::RuntimeRange,
-        string::RuntimeString,
         utils::{resolve_index, resolve_slice_indices},
         RuntimeValue,
     },

--- a/linefeed/src/vm/runtime_value/list.rs
+++ b/linefeed/src/vm/runtime_value/list.rs
@@ -88,16 +88,11 @@ impl RuntimeList {
             .sort_by(|a, b| a.partial_cmp(b).expect("unhandled uncomparable value"));
     }
 
-    pub fn sort_by_key<I, O, E>(
+    pub fn sort_by_key(
         &self,
-        vm: &mut BytecodeInterpreter<I, O, E>,
+        vm: &mut BytecodeInterpreter,
         key_fn: &RuntimeFunction,
-    ) -> Result<(), RuntimeError>
-    where
-        I: std::io::Read,
-        O: std::io::Write,
-        E: std::io::Write,
-    {
+    ) -> Result<(), RuntimeError> {
         let keys = self
             .0
             .borrow()

--- a/linefeed/tests/linefeed/helpers.rs
+++ b/linefeed/tests/linefeed/helpers.rs
@@ -1,6 +1,23 @@
-use std::io::Read;
+use std::{
+    cell::RefCell,
+    io::{Read, Write},
+    rc::Rc,
+};
 
 pub mod output;
+
+/// A wrapper around Rc<RefCell<Vec<u8>>> that implements Write
+struct SharedBuffer(Rc<RefCell<Vec<u8>>>);
+
+impl Write for SharedBuffer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.borrow_mut().flush()
+    }
+}
 
 macro_rules! eval_and_assert {
     ($name:ident, $src:expr, $stdout_assertion:expr, $stderr_assertion:expr) => {
@@ -33,13 +50,20 @@ macro_rules! eval_and_assert {
 
 pub(crate) use eval_and_assert;
 
-pub fn run_program(src: &str, mut input: impl Read) -> (String, String) {
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
+pub fn run_program(src: &str, input: impl Read + 'static) -> (String, String) {
+    let stdout_buf = Rc::new(RefCell::new(Vec::new()));
+    let stderr_buf = Rc::new(RefCell::new(Vec::new()));
 
-    linefeed::run_with_handles(src, &mut input, &mut stdout, &mut stderr);
-    let stdout_str = std::str::from_utf8(&stdout).unwrap().to_string();
-    let stderr_str = std::str::from_utf8(&stderr).unwrap().to_string();
+    let stdout_clone = stdout_buf.clone();
+    let stderr_clone = stderr_buf.clone();
+
+    let stdout = SharedBuffer(stdout_buf);
+    let stderr = SharedBuffer(stderr_buf);
+
+    linefeed::run_with_handles(src, input, stdout, stderr);
+
+    let stdout_str = std::str::from_utf8(&stdout_clone.borrow()).unwrap().to_string();
+    let stderr_str = std::str::from_utf8(&stderr_clone.borrow()).unwrap().to_string();
 
     (stdout_str, stderr_str)
 }

--- a/linefeed/tests/linefeed/main.rs
+++ b/linefeed/tests/linefeed/main.rs
@@ -25,6 +25,7 @@ mod print;
 mod regex;
 mod return_;
 mod scope;
+mod sort;
 mod string;
 mod tuple;
 mod while_loops;

--- a/linefeed/tests/linefeed/sort.rs
+++ b/linefeed/tests/linefeed/sort.rs
@@ -1,0 +1,79 @@
+use crate::helpers::{
+    eval_and_assert,
+    output::{empty, equals},
+};
+
+use indoc::indoc;
+
+eval_and_assert!(
+    sort_integers,
+    indoc! {r#"
+        list = [3, 1, 4, 1, 5, 9, 2, 6];
+        print(list.sort());
+    "#},
+    equals("[1, 1, 2, 3, 4, 5, 6, 9]"),
+    empty()
+);
+
+eval_and_assert!(
+    sort_strings,
+    indoc! {r#"
+        words = ["zebra", "apple", "mango", "banana"];
+        print(words.sort());
+    "#},
+    equals(r#"["apple", "banana", "mango", "zebra"]"#),
+    empty()
+);
+
+eval_and_assert!(
+    sort_in_place_and_returns_list,
+    indoc! {r#"
+        original = [5, 2, 8, 1];
+        reference = original;
+        result = original.sort();
+        print(original);
+        print(reference);
+        print(result);
+        print(result == original);
+    "#},
+    equals(indoc! {r#"
+        [1, 2, 5, 8]
+        [1, 2, 5, 8]
+        [1, 2, 5, 8]
+        true
+    "#}),
+    empty()
+);
+
+eval_and_assert!(
+    sort_by_string_length,
+    indoc! {r#"
+        words = ["a", "abc", "ab", "abcd"];
+        sorted = words.sort(fn (item) item.len());
+        print(sorted);
+    "#},
+    equals(r#"["a", "ab", "abc", "abcd"]"#),
+    empty()
+);
+
+eval_and_assert!(
+    sort_by_custom_key,
+    indoc! {r#"
+        pairs = [[2, "b"], [1, "c"], [3, "a"]];
+        sorted = pairs.sort(fn (pair) pair[1]);
+        print(sorted);
+    "#},
+    equals(r#"[[3, "a"], [2, "b"], [1, "c"]]"#),
+    empty()
+);
+
+eval_and_assert!(
+    sort_by_negative_value,
+    indoc! {r#"
+        nums = [1, 2, 3, 4, 5];
+        sorted = nums.sort(fn (x) -x);
+        print(sorted);
+    "#},
+    equals("[5, 4, 3, 2, 1]"),
+    empty()
+);


### PR DESCRIPTION
Restructures the VM slightly such that the VM can call user functions on demand at runtime.

For example, the user can now pass a "key" function to the `.sort(...)` method, which the VM can invoke itself for each list item. Before, only the user itself could call functions.