### PR TITLE
Clean up I/O types to simplify passing down VM to subfunctions

### DIFF
--- a/linefeed/src/lib.rs
+++ b/linefeed/src/lib.rs
@@ -61,12 +61,15 @@ pub fn run_with_handles(
     };
     let compile_time = Instant::now().duration_since(compile_start);
 
-    program.disassemble(src.as_ref());
+    // program.disassemble(src.as_ref());
 
     let run_start = Instant::now();
 
-    let mut bytecode_interpreter =
-        BytecodeInterpreter::new(program).with_handles(&mut stdin, &mut stdout, &mut stderr);
+    let mut bytecode_interpreter = BytecodeInterpreter::new(program).with_handles(
+        Box::new(&mut stdin),
+        Box::new(&mut stdout),
+        Box::new(&mut stderr),
+    );
 
     if let Err((span, err)) = bytecode_interpreter.run() {
         return pretty_print_errors(stderr, src, vec![Rich::<RuntimeError>::custom(span, err)]);

--- a/linefeed/src/lib.rs
+++ b/linefeed/src/lib.rs
@@ -72,7 +72,8 @@ pub fn run_with_handles(
     );
 
     if let Err((span, err)) = bytecode_interpreter.run() {
-        return pretty_print_errors(io::stderr(), src, vec![Rich::<RuntimeError>::custom(span, err)]);
+        let stderr = std::mem::replace(&mut bytecode_interpreter.stderr, Box::new(io::sink()));
+        return pretty_print_errors(stderr, src, vec![Rich::<RuntimeError>::custom(span, err)]);
     }
 
     let run_time = Instant::now().duration_since(run_start);

--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -333,16 +333,11 @@ impl RuntimeValue {
         })
     }
 
-    pub fn sort<I, O, E>(
+    pub fn sort(
         &self,
-        vm: &mut BytecodeInterpreter<I, O, E>,
+        vm: &mut BytecodeInterpreter,
         key_fn: Option<RuntimeValue>,
-    ) -> Result<Self, RuntimeError>
-    where
-        I: std::io::Read,
-        O: std::io::Write,
-        E: std::io::Write,
-    {
+    ) -> Result<Self, RuntimeError> {
         match self {
             RuntimeValue::List(list) => {
                 match key_fn {

--- a/linefeed/src/vm/runtime_value/list.rs
+++ b/linefeed/src/vm/runtime_value/list.rs
@@ -10,7 +10,6 @@ use crate::vm::{
         number::RuntimeNumber,
         operations::LfAppend,
         range::RuntimeRange,
-        string::RuntimeString,
         utils::{resolve_index, resolve_slice_indices},
         RuntimeValue,
     },

--- a/linefeed/src/vm/runtime_value/list.rs
+++ b/linefeed/src/vm/runtime_value/list.rs
@@ -88,16 +88,11 @@ impl RuntimeList {
             .sort_by(|a, b| a.partial_cmp(b).expect("unhandled uncomparable value"));
     }
 
-    pub fn sort_by_key<I, O, E>(
+    pub fn sort_by_key(
         &self,
-        vm: &mut BytecodeInterpreter<I, O, E>,
+        vm: &mut BytecodeInterpreter,
         key_fn: &RuntimeFunction,
-    ) -> Result<(), RuntimeError>
-    where
-        I: std::io::Read,
-        O: std::io::Write,
-        E: std::io::Write,
-    {
+    ) -> Result<(), RuntimeError> {
         let keys = self
             .0
             .borrow()

--- a/linefeed/tests/linefeed/helpers.rs
+++ b/linefeed/tests/linefeed/helpers.rs
@@ -1,6 +1,23 @@
-use std::io::Read;
+use std::{
+    cell::RefCell,
+    io::{Read, Write},
+    rc::Rc,
+};
 
 pub mod output;
+
+/// A wrapper around Rc<RefCell<Vec<u8>>> that implements Write
+struct SharedBuffer(Rc<RefCell<Vec<u8>>>);
+
+impl Write for SharedBuffer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.borrow_mut().flush()
+    }
+}
 
 macro_rules! eval_and_assert {
     ($name:ident, $src:expr, $stdout_assertion:expr, $stderr_assertion:expr) => {
@@ -33,13 +50,20 @@ macro_rules! eval_and_assert {
 
 pub(crate) use eval_and_assert;
 
-pub fn run_program(src: &str, mut input: impl Read) -> (String, String) {
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
+pub fn run_program(src: &str, input: impl Read + 'static) -> (String, String) {
+    let stdout_buf = Rc::new(RefCell::new(Vec::new()));
+    let stderr_buf = Rc::new(RefCell::new(Vec::new()));
 
-    linefeed::run_with_handles(src, &mut input, &mut stdout, &mut stderr);
-    let stdout_str = std::str::from_utf8(&stdout).unwrap().to_string();
-    let stderr_str = std::str::from_utf8(&stderr).unwrap().to_string();
+    let stdout_clone = stdout_buf.clone();
+    let stderr_clone = stderr_buf.clone();
+
+    let stdout = SharedBuffer(stdout_buf);
+    let stderr = SharedBuffer(stderr_buf);
+
+    linefeed::run_with_handles(src, input, stdout, stderr);
+
+    let stdout_str = std::str::from_utf8(&stdout_clone.borrow()).unwrap().to_string();
+    let stderr_str = std::str::from_utf8(&stderr_clone.borrow()).unwrap().to_string();
 
     (stdout_str, stderr_str)
 }


### PR DESCRIPTION
Cleans up the I/O types for the VM, since passing it down to runtime handlers is very verbose with generics.