### PR TITLE
Support element-wise additions for tuples

### DIFF
--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -91,6 +91,9 @@ impl RuntimeValue {
             )),
             (RuntimeValue::List(a), RuntimeValue::List(b)) => Ok(RuntimeValue::List(a.concat(b))),
             (RuntimeValue::Set(a), RuntimeValue::Set(b)) => Ok(RuntimeValue::Set(a.union(b))),
+            (RuntimeValue::Tuple(a), RuntimeValue::Tuple(b)) => {
+                Ok(RuntimeValue::Tuple(a.element_wise_add(b)?))
+            }
             _ => Err(RuntimeError::invalid_binary_op_for_types(
                 "add", self, other,
             )),

--- a/linefeed/src/vm/runtime_value/tuple.rs
+++ b/linefeed/src/vm/runtime_value/tuple.rs
@@ -37,4 +37,23 @@ impl RuntimeTuple {
     pub fn contains(&self, value: &RuntimeValue) -> bool {
         self.0.iter().any(|v| v == value)
     }
+
+    pub fn element_wise_add(&self, other: &Self) -> Result<Self, RuntimeError> {
+        if self.len() != other.len() {
+            return Err(RuntimeError::TypeMismatch(format!(
+                "Cannot add tuples of different lengths: {} and {}",
+                self.len(),
+                other.len()
+            )));
+        }
+
+        let result: Result<Vec<RuntimeValue>, RuntimeError> = self
+            .0
+            .iter()
+            .zip(other.0.iter())
+            .map(|(a, b)| a.add(b))
+            .collect();
+
+        Ok(RuntimeTuple::from_vec(result?))
+    }
 }

--- a/linefeed/tests/linefeed/advent_of_code_2020/day11.lf
+++ b/linefeed/tests/linefeed/advent_of_code_2020/day11.lf
@@ -10,26 +10,26 @@ while changed {
   changed = false;
   new_seats = {};
 
-  for (r, c), kind in seats {
+  for pos, kind in seats {
     num_occupied = 0;
-    for dr, dc in ((-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)) {
-      if seats[(r + dr, c + dc)] == "#" {
+    for dir in ((-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)) {
+      if seats[pos + dir] == "#" {
         num_occupied += 1;
       };
     };
 
-    new_seats[(r, c)] = kind;
+    new_seats[pos] = kind;
 
     match kind {
       "L" => {
         if num_occupied == 0 {
-          new_seats[(r, c)] = "#";
+          new_seats[pos] = "#";
           changed = true;
         };
       },
       "#" => {
         if num_occupied >= 4 {
-          new_seats[(r, c)] = "L";
+          new_seats[pos] = "L";
           changed = true;
         };
       },

--- a/linefeed/tests/linefeed/tuple.rs
+++ b/linefeed/tests/linefeed/tuple.rs
@@ -1,6 +1,6 @@
 use crate::helpers::{
     eval_and_assert,
-    output::{empty, equals},
+    output::{contains, empty, equals},
 };
 
 use indoc::indoc;
@@ -22,4 +22,59 @@ eval_and_assert!(
         true
     "#}),
     empty()
+);
+
+eval_and_assert!(
+    tuple_element_wise_addition_basic,
+    indoc! {r#"
+        a = (1, 2, 3);
+        b = (4, 5, 6);
+        print(a + b);
+    "#},
+    equals("(5, 7, 9)\n"),
+    empty()
+);
+
+eval_and_assert!(
+    tuple_element_wise_addition_floats,
+    indoc! {r#"
+        a = (1.5, 2.5);
+        b = (3.0, 4.0);
+        print(a + b);
+    "#},
+    equals("(4.5, 6.5)\n"),
+    empty()
+);
+
+eval_and_assert!(
+    tuple_element_wise_addition_strings,
+    indoc! {r#"
+        a = ("hello", "world");
+        b = (" ", "!");
+        print(a + b);
+    "#},
+    equals("(\"hello \", \"world!\")\n"),
+    empty()
+);
+
+eval_and_assert!(
+    tuple_element_wise_addition_nested,
+    indoc! {r#"
+        a = ((1, 2), (3, 4));
+        b = ((5, 6), (7, 8));
+        print(a + b);
+    "#},
+    equals("((6, 8), (10, 12))\n"),
+    empty()
+);
+
+eval_and_assert!(
+    tuple_mismatched_length_error,
+    indoc! {r#"
+        a = (1, 2);
+        b = (3, 4, 5);
+        print(a + b);
+    "#},
+    empty(),
+    contains("Cannot add tuples of different lengths")
 );


### PR DESCRIPTION
An extension of #16, but also modifies the solution slightly to not instantiate new tuples but rather just add together existing ones. Avoids destructuring and avoids creating tuples via bytecode.

This change alone makes time go from ~6.5s to ~3.8s and number of bytecode instructions executed go from ~320M to ~200M.