### PR TITLE
Use standard integers by default and auto-promote to big integers

### DIFF
--- a/linefeed/src/vm/runtime_value/number.rs
+++ b/linefeed/src/vm/runtime_value/number.rs
@@ -43,9 +43,9 @@ impl RuntimeNumber {
     pub fn modulo(&self, other: &Self) -> Self {
         match (self, other) {
             (SmallInt(a), SmallInt(b)) => SmallInt(a % b),
-            (SmallInt(a), BigInt(b)) => BigInt((rug::Integer::from(*a) % b).into()),
+            (SmallInt(a), BigInt(b)) => BigInt(rug::Integer::from(*a) % b),
             (SmallInt(a), Float(b)) => Float(*a as f64 % b),
-            (BigInt(a), SmallInt(b)) => BigInt((a % rug::Integer::from(*b)).into()),
+            (BigInt(a), SmallInt(b)) => BigInt(a % rug::Integer::from(*b)),
             (BigInt(a), BigInt(b)) => BigInt((a % b).into()),
             (BigInt(a), Float(b)) => Float(a.to_f64() % b),
             (Float(a), SmallInt(b)) => Float(a % (*b as f64)),
@@ -67,10 +67,10 @@ impl RuntimeNumber {
                 if *b < 0 {
                     Float((*a as f64).powi(*b as i32))
                 } else {
-                    BigInt(rug::Integer::from(*a).pow(*b as u32).into())
+                    BigInt(rug::Integer::from(*a).pow(*b as u32))
                 }
             }
-            (SmallInt(a), BigInt(b)) => BigInt(rug::Integer::from(*a).pow(b.to_u32().unwrap()).into()),
+            (SmallInt(a), BigInt(b)) => BigInt(rug::Integer::from(*a).pow(b.to_u32().unwrap())),
             (SmallInt(a), Float(b)) => Float((*a as f64).powf(*b)),
             (BigInt(a), SmallInt(b)) => {
                 if *b < 0 {
@@ -90,9 +90,9 @@ impl RuntimeNumber {
     pub fn div_floor(&self, other: &Self) -> Self {
         match (self, other) {
             (SmallInt(a), SmallInt(b)) => SmallInt(a / b),
-            (SmallInt(a), BigInt(b)) => BigInt((rug::Integer::from(*a) / b).into()),
+            (SmallInt(a), BigInt(b)) => BigInt(rug::Integer::from(*a) / b),
             (SmallInt(a), Float(b)) => Float((*a as f64) / b).floor(),
-            (BigInt(a), SmallInt(b)) => BigInt((a / rug::Integer::from(*b)).into()),
+            (BigInt(a), SmallInt(b)) => BigInt(a / rug::Integer::from(*b)),
             (BigInt(a), BigInt(b)) => BigInt((a / b).into()),
             (BigInt(a), Float(b)) => Float(a.to_f64() / b).floor(),
             (Float(a), SmallInt(b)) => Float(a / (*b as f64)).floor(),
@@ -213,14 +213,13 @@ impl Add for RuntimeNumber {
 
     fn add(self, other: Self) -> Self::Output {
         match (self, other) {
-            (SmallInt(a), SmallInt(b)) => {
-                a.checked_add(b)
-                    .map(SmallInt)
-                    .unwrap_or_else(|| BigInt((rug::Integer::from(a) + rug::Integer::from(b)).into()))
-            }
-            (SmallInt(a), BigInt(b)) => BigInt((rug::Integer::from(a) + b).into()),
+            (SmallInt(a), SmallInt(b)) => a
+                .checked_add(b)
+                .map(SmallInt)
+                .unwrap_or_else(|| BigInt(rug::Integer::from(a) + rug::Integer::from(b))),
+            (SmallInt(a), BigInt(b)) => BigInt(rug::Integer::from(a) + b),
             (SmallInt(a), Float(b)) => Float(a as f64 + b),
-            (BigInt(a), SmallInt(b)) => BigInt((a + rug::Integer::from(b)).into()),
+            (BigInt(a), SmallInt(b)) => BigInt(a + rug::Integer::from(b)),
             (BigInt(a), BigInt(b)) => BigInt(a + b),
             (BigInt(a), Float(b)) => Float(a.to_f64() + b),
             (Float(a), SmallInt(b)) => Float(a + b as f64),
@@ -235,14 +234,13 @@ impl Add<&Self> for RuntimeNumber {
 
     fn add(self, other: &Self) -> Self::Output {
         match (self, other) {
-            (SmallInt(a), SmallInt(b)) => {
-                a.checked_add(*b)
-                    .map(SmallInt)
-                    .unwrap_or_else(|| BigInt((rug::Integer::from(a) + rug::Integer::from(*b)).into()))
-            }
-            (SmallInt(a), BigInt(b)) => BigInt((rug::Integer::from(a) + b).into()),
+            (SmallInt(a), SmallInt(b)) => a
+                .checked_add(*b)
+                .map(SmallInt)
+                .unwrap_or_else(|| BigInt(rug::Integer::from(a) + rug::Integer::from(*b))),
+            (SmallInt(a), BigInt(b)) => BigInt(rug::Integer::from(a) + b),
             (SmallInt(a), Float(b)) => Float(a as f64 + b),
-            (BigInt(a), SmallInt(b)) => BigInt((a + rug::Integer::from(*b)).into()),
+            (BigInt(a), SmallInt(b)) => BigInt(a + rug::Integer::from(*b)),
             (BigInt(a), BigInt(b)) => BigInt(a + b),
             (BigInt(a), Float(b)) => Float(a.to_f64() + b),
             (Float(a), SmallInt(b)) => Float(a + *b as f64),
@@ -257,14 +255,13 @@ impl Add for &RuntimeNumber {
 
     fn add(self, other: Self) -> Self::Output {
         match (self, other) {
-            (SmallInt(a), SmallInt(b)) => {
-                a.checked_add(*b)
-                    .map(SmallInt)
-                    .unwrap_or_else(|| BigInt((rug::Integer::from(*a) + rug::Integer::from(*b)).into()))
-            }
-            (SmallInt(a), BigInt(b)) => BigInt((rug::Integer::from(*a) + b).into()),
+            (SmallInt(a), SmallInt(b)) => a
+                .checked_add(*b)
+                .map(SmallInt)
+                .unwrap_or_else(|| BigInt(rug::Integer::from(*a) + rug::Integer::from(*b))),
+            (SmallInt(a), BigInt(b)) => BigInt(rug::Integer::from(*a) + b),
             (SmallInt(a), Float(b)) => Float(*a as f64 + b),
-            (BigInt(a), SmallInt(b)) => BigInt((a + rug::Integer::from(*b)).into()),
+            (BigInt(a), SmallInt(b)) => BigInt(a + rug::Integer::from(*b)),
             (BigInt(a), BigInt(b)) => BigInt((a + b).into()),
             (BigInt(a), Float(b)) => Float(a.to_f64() + b),
             (Float(a), SmallInt(b)) => Float(a + *b as f64),
@@ -279,14 +276,13 @@ impl Sub for RuntimeNumber {
 
     fn sub(self, other: Self) -> Self::Output {
         match (self, other) {
-            (SmallInt(a), SmallInt(b)) => {
-                a.checked_sub(b)
-                    .map(SmallInt)
-                    .unwrap_or_else(|| BigInt((rug::Integer::from(a) - rug::Integer::from(b)).into()))
-            }
-            (SmallInt(a), BigInt(b)) => BigInt((rug::Integer::from(a) - b).into()),
+            (SmallInt(a), SmallInt(b)) => a
+                .checked_sub(b)
+                .map(SmallInt)
+                .unwrap_or_else(|| BigInt(rug::Integer::from(a) - rug::Integer::from(b))),
+            (SmallInt(a), BigInt(b)) => BigInt(rug::Integer::from(a) - b),
             (SmallInt(a), Float(b)) => Float(a as f64 - b),
-            (BigInt(a), SmallInt(b)) => BigInt((a - rug::Integer::from(b)).into()),
+            (BigInt(a), SmallInt(b)) => BigInt(a - rug::Integer::from(b)),
             (BigInt(a), BigInt(b)) => BigInt(a - b),
             (BigInt(a), Float(b)) => Float(a.to_f64() - b),
             (Float(a), SmallInt(b)) => Float(a - b as f64),
@@ -301,14 +297,13 @@ impl Sub for &RuntimeNumber {
 
     fn sub(self, other: Self) -> Self::Output {
         match (self, other) {
-            (SmallInt(a), SmallInt(b)) => {
-                a.checked_sub(*b)
-                    .map(SmallInt)
-                    .unwrap_or_else(|| BigInt((rug::Integer::from(*a) - rug::Integer::from(*b)).into()))
-            }
-            (SmallInt(a), BigInt(b)) => BigInt((rug::Integer::from(*a) - b).into()),
+            (SmallInt(a), SmallInt(b)) => a
+                .checked_sub(*b)
+                .map(SmallInt)
+                .unwrap_or_else(|| BigInt(rug::Integer::from(*a) - rug::Integer::from(*b))),
+            (SmallInt(a), BigInt(b)) => BigInt(rug::Integer::from(*a) - b),
             (SmallInt(a), Float(b)) => Float(*a as f64 - b),
-            (BigInt(a), SmallInt(b)) => BigInt((a - rug::Integer::from(*b)).into()),
+            (BigInt(a), SmallInt(b)) => BigInt(a - rug::Integer::from(*b)),
             (BigInt(a), BigInt(b)) => BigInt((a - b).into()),
             (BigInt(a), Float(b)) => Float(a.to_f64() - b),
             (Float(a), SmallInt(b)) => Float(a - *b as f64),
@@ -323,14 +318,13 @@ impl Mul for RuntimeNumber {
 
     fn mul(self, other: Self) -> Self::Output {
         match (self, other) {
-            (SmallInt(a), SmallInt(b)) => {
-                a.checked_mul(b)
-                    .map(SmallInt)
-                    .unwrap_or_else(|| BigInt((rug::Integer::from(a) * rug::Integer::from(b)).into()))
-            }
-            (SmallInt(a), BigInt(b)) => BigInt((rug::Integer::from(a) * b).into()),
+            (SmallInt(a), SmallInt(b)) => a
+                .checked_mul(b)
+                .map(SmallInt)
+                .unwrap_or_else(|| BigInt(rug::Integer::from(a) * rug::Integer::from(b))),
+            (SmallInt(a), BigInt(b)) => BigInt(rug::Integer::from(a) * b),
             (SmallInt(a), Float(b)) => Float(a as f64 * b),
-            (BigInt(a), SmallInt(b)) => BigInt((a * rug::Integer::from(b)).into()),
+            (BigInt(a), SmallInt(b)) => BigInt(a * rug::Integer::from(b)),
             (BigInt(a), BigInt(b)) => BigInt(a * b),
             (BigInt(a), Float(b)) => Float(a.to_f64() * b),
             (Float(a), SmallInt(b)) => Float(a * b as f64),
@@ -345,14 +339,13 @@ impl Mul for &RuntimeNumber {
 
     fn mul(self, other: Self) -> Self::Output {
         match (self, other) {
-            (SmallInt(a), SmallInt(b)) => {
-                a.checked_mul(*b)
-                    .map(SmallInt)
-                    .unwrap_or_else(|| BigInt((rug::Integer::from(*a) * rug::Integer::from(*b)).into()))
-            }
-            (SmallInt(a), BigInt(b)) => BigInt((rug::Integer::from(*a) * b).into()),
+            (SmallInt(a), SmallInt(b)) => a
+                .checked_mul(*b)
+                .map(SmallInt)
+                .unwrap_or_else(|| BigInt(rug::Integer::from(*a) * rug::Integer::from(*b))),
+            (SmallInt(a), BigInt(b)) => BigInt(rug::Integer::from(*a) * b),
             (SmallInt(a), Float(b)) => Float(*a as f64 * b),
-            (BigInt(a), SmallInt(b)) => BigInt((a * rug::Integer::from(*b)).into()),
+            (BigInt(a), SmallInt(b)) => BigInt(a * rug::Integer::from(*b)),
             (BigInt(a), BigInt(b)) => BigInt((a * b).into()),
             (BigInt(a), Float(b)) => Float(a.to_f64() * b),
             (Float(a), SmallInt(b)) => Float(a * *b as f64),


### PR DESCRIPTION
This PR introduces a `SmallInt` variant to `RuntimeNumber`, which just stores an `isize` in order to make cloning much cheaper for *most* numbers. The increased cost of big integers will now only apply when the number is auto-promoted to a big int.

## Motivation

I discovered that `rug::Integer` allocates on the heap for its value data [docs.rs](https://docs.rs/rug/latest/rug/integer/index.html#:~:text=This%20module%20provides%20support%20for,can%20use%20the%20MiniInteger%20type).

This means that each time we add or multiply, a new big integer is created (and allocated on the heap) and later freed. I noticed in a flamegraph when profiling that a lot of time was spent on cloning/freeing. I suspect this is because the program is churning through memory allocations for these big integers.

The code I profiled was:

```rust
for i in 0..n {
  for j in i+1..n {
    part1 = rep[i] * rep[j] if rep[i] + rep[j] == 2020;
    for k in j+1..n {
      part2 = rep[i] * rep[j] * rep[k] if rep[i] + rep[j] + rep[k] == 2020;
    };
  };
};
```

It went from ~550 ms to ~330ms (n = 200), so def. an impact.

## Example

A more comprehensive example that focuses on integer arithmetic.

```rust
sum = 0;
for i in 1..100000000 {
  sum += i;
};
print(sum);
```

**Before this PR:**
```
4999999950000000
Parse time: 702.416µs, Compile time: 77.042µs, Run time: 17.784223125s. 1100000015 instructions executed.
```

**After this PR:**
```
4999999950000000
Parse time: 677.916µs, Compile time: 70.042µs, Run time: 9.661440083s. 1100000015 instructions executed.
```

That's ~17.8s to 9.6s. Pretty impactful.