### PR TITLE
Move all allocation to an arena allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "httparse"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +498,7 @@ dependencies = [
  "ariadne",
  "chumsky",
  "indoc",
+ "ouroboros",
  "oxc_allocator",
  "regex",
  "rug",
@@ -574,6 +587,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "oxc_allocator"
 version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +697,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi 1.0.1",
 ]
 
 [[package]]
@@ -872,6 +922,12 @@ dependencies = [
  "psm",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -1094,6 +1150,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vte"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+dependencies = [
+ "allocator-api2",
+]
+
+[[package]]
 name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +486,7 @@ dependencies = [
  "ariadne",
  "chumsky",
  "indoc",
+ "oxc_allocator",
  "regex",
  "rug",
  "rustc-hash",
@@ -553,6 +572,25 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "oxc_allocator"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71ef2dba21be1ce515378b2b7143eaa2a912f9e6ffe162ae20639d56f53d60e3"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.16.0",
+ "oxc_data_structures",
+ "rustc-hash",
+]
+
+[[package]]
+name = "oxc_data_structures"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f5171d7b8bc907a1b29e557d14f8478509a2154272d56db9ee8aed6bfe8dec"
 
 [[package]]
 name = "parking_lot"

--- a/linefeed/Cargo.toml
+++ b/linefeed/Cargo.toml
@@ -11,6 +11,7 @@ debug-vm = []
 [dependencies]
 ariadne = "0.3.0"
 chumsky = { git = "https://github.com/zesterer/chumsky.git", rev = "282bf5e", features = ["memoization"] }
+ouroboros = "0.18.5"
 oxc_allocator = "0.96.0"
 regex = "1.11.1"
 rug = "1.27.0"

--- a/linefeed/Cargo.toml
+++ b/linefeed/Cargo.toml
@@ -11,6 +11,7 @@ debug-vm = []
 [dependencies]
 ariadne = "0.3.0"
 chumsky = { git = "https://github.com/zesterer/chumsky.git", rev = "282bf5e", features = ["memoization"] }
+oxc_allocator = "0.96.0"
 regex = "1.11.1"
 rug = "1.27.0"
 rustc-hash = "2.1.1"

--- a/linefeed/src/compiler.rs
+++ b/linefeed/src/compiler.rs
@@ -12,7 +12,7 @@ use crate::{
     grammar::ast::{AstValue, BinaryOp, Expr, Pattern, Span, Spanned, UnaryOp},
     vm::{
         bytecode::Bytecode,
-        runtime_value::{function::RuntimeFunction, number::RuntimeNumber},
+        runtime_value::function::RuntimeFunction,
     },
 };
 

--- a/linefeed/src/compiler.rs
+++ b/linefeed/src/compiler.rs
@@ -97,6 +97,7 @@ pub enum Instruction {
 }
 
 use chumsky::span::Span as _;
+use oxc_allocator::Allocator;
 use Instruction::*;
 
 type LoopId = Span;
@@ -117,7 +118,11 @@ pub struct Compiler {
 }
 
 impl Compiler {
-    pub fn compile(&mut self, expr: &Spanned<Expr>) -> Result<Program<Bytecode>, CompileError> {
+    pub fn compile<'gc>(
+        &mut self,
+        expr: &Spanned<Expr>,
+        allocator: &'gc Allocator,
+    ) -> Result<Program<Bytecode<'gc>>, CompileError> {
         let program = self
             .compile_allocation_for_all_vars_in_scope(expr)
             .then_program(self.compile_expr(expr)?)
@@ -129,7 +134,7 @@ impl Compiler {
         //  - [ ] Remove unnecessary additions
         //  - [ ] Don't do lookups on constants, just insert them
 
-        let bytecode_program = program.into_bytecode()?;
+        let bytecode_program = program.into_bytecode(&allocator)?;
 
         Ok(bytecode_program)
     }

--- a/linefeed/src/compiler.rs
+++ b/linefeed/src/compiler.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, ops::RangeInclusive};
 
 use crate::{
     compiler::{
-        ir_value::IrValue,
+        ir_value::{IrNumber, IrValue},
         method::Method,
         scoped_map::{ScopedMap, VarType},
         stdlib_fn::StdlibFn,
@@ -134,7 +134,7 @@ impl Compiler {
         //  - [ ] Remove unnecessary additions
         //  - [ ] Don't do lookups on constants, just insert them
 
-        let bytecode_program = program.into_bytecode(&allocator)?;
+        let bytecode_program = program.into_bytecode(allocator)?;
 
         Ok(bytecode_program)
     }
@@ -268,7 +268,7 @@ impl Compiler {
 
                 let to_add = match op {
                     UnaryOp::Not => vec![Not],
-                    UnaryOp::Neg => vec![Value(IrValue::Num(RuntimeNumber::from(-1))), Mul],
+                    UnaryOp::Neg => vec![Value(IrValue::Num(IrNumber::Int(-1))), Mul],
                 };
 
                 program.then_instructions(to_add, expr.span())
@@ -753,7 +753,7 @@ impl Compiler {
                 .into_iter()
                 .enumerate()
                 .fold(Program::new(), |program, (i, p)| {
-                    let index = Value(IrValue::Num(RuntimeNumber::from(i as isize)));
+                    let index = Value(IrValue::Num(IrNumber::Int(i as i64)));
                     program
                         .then_instructions(vec![Dup, index, Index], expr.span())
                         .then_program(p)

--- a/linefeed/src/compiler/ir_value.rs
+++ b/linefeed/src/compiler/ir_value.rs
@@ -1,7 +1,13 @@
+use oxc_allocator::Allocator;
+
 use crate::{
     compiler::Label,
     grammar::ast::AstValue,
-    vm::runtime_value::{function::RuntimeFunction, number::RuntimeNumber, regex::RegexModifiers},
+    vm::runtime_value::{
+        function::RuntimeFunction,
+        number::{FromWithAlloc, RuntimeNumber},
+        regex::RegexModifiers,
+    },
 };
 
 #[derive(Debug, Clone)]
@@ -10,7 +16,7 @@ pub enum IrValue {
     Uninit,
     Bool(bool),
     Int(isize),
-    Num(RuntimeNumber),
+    Num(IrNumber),
     Str(String),
     Regex(String, RegexModifiers),
     List(Vec<IrValue>),
@@ -41,8 +47,8 @@ impl TryFrom<&AstValue<'_>> for IrValue {
         let res = match val {
             AstValue::Null => IrValue::Null,
             AstValue::Bool(b) => IrValue::Bool(*b),
-            AstValue::Int(n) => IrValue::Num(RuntimeNumber::from(*n)),
-            AstValue::Float(n) => IrValue::Num(RuntimeNumber::Float(*n)),
+            AstValue::Int(n) => IrValue::Num(IrNumber::Int(*n)),
+            AstValue::Float(n) => IrValue::Num(IrNumber::Float(*n)),
             AstValue::Str(s) => IrValue::Str(s.to_string()),
             AstValue::List(xs) => IrValue::List(collect_try_from(xs)?),
             AstValue::Tuple(xs) => IrValue::Tuple(collect_try_from(xs)?),
@@ -51,5 +57,27 @@ impl TryFrom<&AstValue<'_>> for IrValue {
         };
 
         Ok(res)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum IrNumber {
+    Int(i64),
+    Float(f64),
+}
+
+impl IrNumber {
+    pub fn neg(&self) -> Self {
+        match self {
+            IrNumber::Int(n) => IrNumber::Int(-n),
+            IrNumber::Float(n) => IrNumber::Float(-n),
+        }
+    }
+
+    pub fn to_runtime_number<'gc>(&self, alloc: &'gc Allocator) -> RuntimeNumber<'gc> {
+        match self {
+            IrNumber::Int(n) => RuntimeNumber::from_with_alloc(*n, alloc),
+            IrNumber::Float(n) => RuntimeNumber::Float(*n),
+        }
     }
 }

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -234,7 +234,7 @@ where
             Bytecode::GreaterEq => binary_op!(self, greater_than_or_eq),
             Bytecode::Range => binary_op!(self, range),
             Bytecode::Xor => binary_op!(self, xor),
-            Bytecode::BitwiseAnd => binary_op!(self, bitwise_and),
+            Bytecode::BitwiseAnd => binary_op_alloc!(self, bitwise_and),
 
             Bytecode::Not => {
                 let val = self.pop_stack();

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -503,7 +503,7 @@ where
                 self.push_stack(RuntimeValue::Tuple(tup));
             }
             Bytecode::ToMap => stdlib_fn!(self, to_map),
-            Bytecode::MapWithDefault => stdlib_fn!(self, map_with_default),
+            Bytecode::MapWithDefault => stdlib_fn_alloc!(self, map_with_default),
             Bytecode::ToSet(num_args) => stdlib_fn_with_optional_arg!(self, to_set, *num_args),
             // Bytecode::ToCounter(num_args) => {
             //     stdlib_fn_with_optional_arg!(self, to_counter, *num_args)

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -89,13 +89,6 @@ macro_rules! binary_op_swapped {
 macro_rules! unary_mapper_method {
     ($vm:expr, $method:ident) => {{
         let val = $vm.pop_stack();
-        $vm.push_stack(val.$method()?);
-    }};
-}
-
-macro_rules! unary_mapper_method_alloc {
-    ($vm:expr, $method:ident) => {{
-        let val = $vm.pop_stack();
         $vm.push_stack(val.$method($vm.allocator)?);
     }};
 }
@@ -474,22 +467,22 @@ where
                 self.pop_stack();
             }
 
-            Bytecode::ToIter => unary_mapper_method_alloc!(self, to_iter),
-            Bytecode::ToUpperCase => unary_mapper_method_alloc!(self, to_uppercase),
-            Bytecode::ToLowerCase => unary_mapper_method_alloc!(self, to_lowercase),
+            Bytecode::ToIter => unary_mapper_method!(self, to_iter),
+            Bytecode::ToUpperCase => unary_mapper_method!(self, to_uppercase),
+            Bytecode::ToLowerCase => unary_mapper_method!(self, to_lowercase),
             Bytecode::Split => binary_op_alloc!(self, split),
-            Bytecode::SplitLines => unary_mapper_method_alloc!(self, lines),
+            Bytecode::SplitLines => unary_mapper_method!(self, lines),
             Bytecode::Join(num_args) => method_with_optional_arg!(self, join, *num_args),
-            Bytecode::Length => unary_mapper_method_alloc!(self, length),
+            Bytecode::Length => unary_mapper_method!(self, length),
             Bytecode::Count => binary_op_alloc!(self, count),
             Bytecode::FindAll => binary_op_alloc!(self, find_all),
             Bytecode::Find => binary_op_alloc!(self, find),
             Bytecode::IsMatch => binary_op!(self, is_match),
             Bytecode::Contains => binary_op!(self, contains),
             Bytecode::IsIn => binary_op_swapped!(self, contains),
-            Bytecode::Enumerate => unary_mapper_method_alloc!(self, enumerate),
+            Bytecode::Enumerate => unary_mapper_method!(self, enumerate),
             Bytecode::GetAll => binary_op_alloc!(self, get_all),
-            Bytecode::Values => unary_mapper_method_alloc!(self, values),
+            Bytecode::Values => unary_mapper_method!(self, values),
 
             Bytecode::ParseInt => stdlib_fn!(self, parse_int),
             Bytecode::ToList => stdlib_fn_alloc!(self, to_list),

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -215,17 +215,12 @@ where
             }
 
             Bytecode::Add => binary_op_alloc!(self, add),
-            Bytecode::Sub => binary_op!(self, sub),
-            Bytecode::Mul => {
-                let rhs = self.pop_stack();
-                let lhs = self.pop_stack();
-                let res = lhs.mul(&rhs, &self.allocator)?;
-                self.push_stack(res);
-            }
+            Bytecode::Sub => binary_op_alloc!(self, sub),
+            Bytecode::Mul => binary_op_alloc!(self, mul),
             Bytecode::Div => binary_op!(self, div),
-            Bytecode::DivFloor => binary_op!(self, div_floor),
-            Bytecode::Mod => binary_op!(self, modulo),
-            Bytecode::Pow => binary_op!(self, pow),
+            Bytecode::DivFloor => binary_op_alloc!(self, div_floor),
+            Bytecode::Mod => binary_op_alloc!(self, modulo),
+            Bytecode::Pow => binary_op_alloc!(self, pow),
             Bytecode::Eq => binary_op!(self, eq_bool),
             Bytecode::NotEq => binary_op!(self, not_eq_bool),
             Bytecode::Less => binary_op!(self, less_than),
@@ -485,8 +480,8 @@ where
             Bytecode::Split => binary_op_alloc!(self, split),
             Bytecode::SplitLines => unary_mapper_method_alloc!(self, lines),
             Bytecode::Join(num_args) => method_with_optional_arg!(self, join, *num_args),
-            Bytecode::Length => unary_mapper_method!(self, length),
-            Bytecode::Count => binary_op!(self, count),
+            Bytecode::Length => unary_mapper_method_alloc!(self, length),
+            Bytecode::Count => binary_op_alloc!(self, count),
             Bytecode::FindAll => binary_op_alloc!(self, find_all),
             Bytecode::Find => binary_op_alloc!(self, find),
             Bytecode::IsMatch => binary_op!(self, is_match),

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -426,7 +426,7 @@ where
             Bytecode::NextIterOrJump(end_label) => {
                 let end_label = *end_label;
                 let iter = self.pop_stack();
-                let value = iter.next()?;
+                let value = iter.next(self.allocator)?;
 
                 if let Some(value) = value {
                     self.push_stack(value);
@@ -437,7 +437,7 @@ where
 
             Bytecode::NextIter => {
                 let iter = self.pop_stack();
-                let value = iter.next()?;
+                let value = iter.next(self.allocator)?;
                 let has_value = RuntimeValue::Bool(value.is_some());
 
                 if let Some(value) = value {
@@ -487,7 +487,7 @@ where
             Bytecode::IsMatch => binary_op!(self, is_match),
             Bytecode::Contains => binary_op!(self, contains),
             Bytecode::IsIn => binary_op_swapped!(self, contains),
-            Bytecode::Enumerate => unary_mapper_method!(self, enumerate),
+            Bytecode::Enumerate => unary_mapper_method_alloc!(self, enumerate),
             Bytecode::GetAll => binary_op_alloc!(self, get_all),
             Bytecode::Values => unary_mapper_method_alloc!(self, values),
 

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -240,7 +240,7 @@ impl<'gc> Bytecode<'gc> {
             IrValue::Uninit => RuntimeValue::Uninit,
             IrValue::Bool(b) => RuntimeValue::Bool(b),
             IrValue::Int(i) => RuntimeValue::Int(i),
-            IrValue::Num(n) => RuntimeValue::Num(n),
+            IrValue::Num(n) => RuntimeValue::Num(n.to_runtime_number(allocator)),
             IrValue::Str(s) => RuntimeValue::Str(RuntimeString::new(s)),
             IrValue::List(xs) => {
                 let items = xs

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -241,7 +241,7 @@ impl<'gc> Bytecode<'gc> {
             IrValue::Bool(b) => RuntimeValue::Bool(b),
             IrValue::Int(i) => RuntimeValue::Int(i),
             IrValue::Num(n) => RuntimeValue::Num(n.to_runtime_number(allocator)),
-            IrValue::Str(s) => RuntimeValue::Str(RuntimeString::new(s)),
+            IrValue::Str(s) => RuntimeValue::Str(RuntimeString::alloc_from_str(s, allocator)),
             IrValue::List(xs) => {
                 let items = xs
                     .into_iter()
@@ -291,7 +291,7 @@ impl<'gc> Bytecode<'gc> {
                 let regex = RuntimeRegex::compile(&s, modifiers)
                     .map_err(|e| CompileError::Plain(format!("Invalid regex: {e}")))?;
 
-                RuntimeValue::Regex(regex)
+                RuntimeValue::Regex(regex.alloc(allocator))
             }
         };
 

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -251,9 +251,9 @@ impl<'gc> Bytecode<'gc> {
                 let items = xs
                     .into_iter()
                     .map(|item| Self::into_runtime_value_with_mapper(item, label_mapper, allocator))
-                    .collect::<Result<_, _>>()?;
+                    .collect::<Result<Vec<_>, _>>()?;
 
-                RuntimeValue::Tuple(allocator.alloc(RuntimeTuple::from_vec(items)))
+                RuntimeValue::Tuple(allocator.alloc(RuntimeTuple::from_iter(items, allocator)))
             }
             IrValue::Set(xs) => {
                 let items = xs

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -279,11 +279,14 @@ impl<'gc> Bytecode<'gc> {
 
                 RuntimeValue::Map(RuntimeMap::from_iter(map, allocator).alloc(allocator))
             }
-            IrValue::Function(func) => RuntimeValue::Function(Rc::new(RuntimeFunction {
-                location: label_mapper.get(func.location)?,
-                arity: func.arity,
-                is_memoized: func.is_memoized,
-            })),
+            IrValue::Function(func) => RuntimeValue::Function(
+                RuntimeFunction {
+                    location: label_mapper.get(func.location)?,
+                    arity: func.arity,
+                    is_memoized: func.is_memoized,
+                }
+                .alloc(allocator),
+            ),
             IrValue::Regex(s, modifiers) => {
                 let regex = RuntimeRegex::compile(&s, modifiers)
                     .map_err(|e| CompileError::Plain(format!("Invalid regex: {e}")))?;

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -275,9 +275,9 @@ impl<'gc> Bytecode<'gc> {
                             Self::into_runtime_value_with_mapper(value, label_mapper, allocator)?,
                         ))
                     })
-                    .collect::<Result<_, _>>()?;
+                    .collect::<Result<HashMap<_, _>, _>>()?;
 
-                RuntimeValue::Map(RuntimeMap::from_map(map))
+                RuntimeValue::Map(RuntimeMap::from_iter(map, allocator).alloc(allocator))
             }
             IrValue::Function(func) => RuntimeValue::Function(Rc::new(RuntimeFunction {
                 location: label_mapper.get(func.location)?,

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    rc::Rc,
-};
+use std::collections::{HashMap, HashSet};
 
 use oxc_allocator::Allocator;
 

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, rc::Rc};
+use std::{
+    collections::{HashMap, HashSet},
+    rc::Rc,
+};
 
 use oxc_allocator::Allocator;
 
@@ -243,9 +246,9 @@ impl<'gc> Bytecode<'gc> {
                 let items = xs
                     .into_iter()
                     .map(|item| Self::into_runtime_value_with_mapper(item, label_mapper, allocator))
-                    .collect::<Result<_, _>>()?;
+                    .collect::<Result<Vec<_>, _>>()?;
 
-                RuntimeValue::List(RuntimeList::from_vec(items))
+                RuntimeValue::List(RuntimeList::from_iter(items, allocator).alloc(allocator))
             }
             IrValue::Tuple(xs) => {
                 let items = xs
@@ -253,15 +256,15 @@ impl<'gc> Bytecode<'gc> {
                     .map(|item| Self::into_runtime_value_with_mapper(item, label_mapper, allocator))
                     .collect::<Result<Vec<_>, _>>()?;
 
-                RuntimeValue::Tuple(allocator.alloc(RuntimeTuple::from_iter(items, allocator)))
+                RuntimeValue::Tuple(RuntimeTuple::from_iter(items, allocator).alloc(allocator))
             }
             IrValue::Set(xs) => {
                 let items = xs
                     .into_iter()
                     .map(|item| Self::into_runtime_value_with_mapper(item, label_mapper, allocator))
-                    .collect::<Result<_, _>>()?;
+                    .collect::<Result<HashSet<_>, _>>()?;
 
-                RuntimeValue::Set(RuntimeSet::from_set(items))
+                RuntimeValue::Set(RuntimeSet::from_iter(items, allocator).alloc(allocator))
             }
             IrValue::Map(m) => {
                 let map = m

--- a/linefeed/src/vm/runtime_error.rs
+++ b/linefeed/src/vm/runtime_error.rs
@@ -1,14 +1,11 @@
-use crate::{
-    compiler::method::Method,
-    vm::{bytecode::Bytecode, runtime_value::RuntimeValue},
-};
+use crate::{compiler::method::Method, vm::runtime_value::RuntimeValue};
 
 #[derive(Debug, Clone)]
 pub enum RuntimeError {
     Plain(String),
     StackUnderflow,
-    NotImplemented(Bytecode),
-    InvalidAddress(RuntimeValue),
+    NotImplemented(String),
+    InvalidAddress(&'static str),
     TypeMismatch(String),
     InternalBug(String),
     IndexOutOfBounds(isize, usize),
@@ -43,10 +40,10 @@ impl std::fmt::Display for RuntimeError {
             RuntimeError::Plain(msg) => write!(f, "{msg}"),
             RuntimeError::StackUnderflow => write!(f, "Stack underflow"),
             RuntimeError::NotImplemented(instr) => {
-                write!(f, "Instruction not implemented: {instr:?}")
+                write!(f, "Instruction not implemented: {instr}")
             }
-            RuntimeError::InvalidAddress(val) => {
-                write!(f, "Invalid address of type {}", val.kind_str())
+            RuntimeError::InvalidAddress(kind_str) => {
+                write!(f, "Invalid address of type {}", kind_str)
             }
             RuntimeError::TypeMismatch(msg) => {
                 write!(f, "Type mismatch: {msg}")

--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -267,7 +267,7 @@ impl<'gc> RuntimeValue<'gc> {
             RuntimeValue::Str(s) => {
                 RuntimeIterator::from(StringIterator::new(s, alloc)).alloc(alloc)
             }
-            RuntimeValue::Map(m) => RuntimeIterator::from(MapIterator::new(m, alloc)).alloc(alloc),
+            RuntimeValue::Map(m) => RuntimeIterator::from(MapIterator::new(m)).alloc(alloc),
             _ => {
                 return Err(RuntimeError::TypeMismatch(format!(
                     "Cannot iterate over '{}'",

--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -475,16 +475,16 @@ impl<'old, 'new> oxc_allocator::CloneIn<'new> for RuntimeValue<'old> {
             RuntimeValue::Uninit => RuntimeValue::Uninit,
             RuntimeValue::Bool(b) => RuntimeValue::Bool(*b),
             RuntimeValue::Int(n) => RuntimeValue::Int(*n),
-            // RuntimeValue::Num(n) => todo!(),
+            RuntimeValue::Num(n) => RuntimeValue::Num(n.clone_in(alloc)),
             // RuntimeValue::Str(s) => RuntimeValue::Str(s.clone_in(alloc)),
             RuntimeValue::List(xs) => RuntimeValue::List(xs.clone_in(alloc).alloc(alloc)),
-            // RuntimeValue::Tuple(xs) => RuntimeValue::Tuple(xs.clone_in(alloc)),
+            RuntimeValue::Tuple(xs) => RuntimeValue::Tuple(xs.clone_in(alloc).alloc(alloc)),
             // RuntimeValue::Set(xs) => RuntimeValue::Set(xs.clone_in(alloc)),
             RuntimeValue::Map(m) => RuntimeValue::Map(m.clone_in(alloc).alloc(alloc)),
             // RuntimeValue::Counter(c) => RuntimeValue::Counter(c.clone_in(alloc)),
             // RuntimeValue::Function(_) => self.clone(),
             // RuntimeValue::Regex(r) => RuntimeValue::Regex(r.clone_in(alloc)),
-            _ => unimplemented!("deep_clone for {:?}", self),
+            _ => unimplemented!("clone_in for {:?}", self),
         }
     }
 }

--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::mutable_key_type)]
 
-use std::{cell::Cell, cmp::Ordering, io::Write, ops::Deref, rc::Rc};
+use std::{cmp::Ordering, io::Write};
 
 use oxc_allocator::{Allocator, Vec as AVec};
 
@@ -383,7 +383,7 @@ impl<'gc> RuntimeValue<'gc> {
                     None => list.sort(),
                 };
 
-                Ok(RuntimeValue::List(list.clone()))
+                Ok(RuntimeValue::List(list))
             }
             _ => Err(RuntimeError::invalid_method_for_type(Method::Sort, self)),
         }

--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -267,7 +267,7 @@ impl<'gc> RuntimeValue<'gc> {
             RuntimeValue::Str(s) => {
                 RuntimeIterator::from(StringIterator::new(s, alloc)).alloc(alloc)
             }
-            RuntimeValue::Map(m) => RuntimeIterator::from(MapIterator::from(*m)).alloc(alloc),
+            RuntimeValue::Map(m) => RuntimeIterator::from(MapIterator::new(m, alloc)).alloc(alloc),
             _ => {
                 return Err(RuntimeError::TypeMismatch(format!(
                     "Cannot iterate over '{}'",

--- a/linefeed/src/vm/runtime_value/counter.rs
+++ b/linefeed/src/vm/runtime_value/counter.rs
@@ -13,19 +13,19 @@ use crate::vm::{
 };
 
 #[derive(Debug, Clone)]
-pub struct RuntimeCounter(Rc<RefCell<InnerRuntimeCounter>>);
+pub struct RuntimeCounter<'gc>(Rc<RefCell<InnerRuntimeCounter<'gc>>>);
 
 #[derive(Debug, Clone)]
-pub struct InnerRuntimeCounter {
-    pub map: FxHashMap<RuntimeValue, isize>,
+pub struct InnerRuntimeCounter<'gc> {
+    pub map: FxHashMap<RuntimeValue<'gc>, isize>,
 }
 
-impl RuntimeCounter {
+impl<'gc> RuntimeCounter<'gc> {
     pub fn new() -> Self {
         Self::from_map(FxHashMap::default())
     }
 
-    pub fn from_map(map: FxHashMap<RuntimeValue, isize>) -> Self {
+    pub fn from_map(map: FxHashMap<RuntimeValue<'gc>, isize>) -> Self {
         Self(Rc::new(RefCell::new(InnerRuntimeCounter { map })))
     }
 

--- a/linefeed/src/vm/runtime_value/function.rs
+++ b/linefeed/src/vm/runtime_value/function.rs
@@ -1,3 +1,5 @@
+use oxc_allocator::Allocator;
+
 use crate::vm::runtime_value::RuntimeValue;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6,6 +8,12 @@ pub struct RuntimeFunction<L = usize> {
     pub location: L,
     pub is_memoized: bool,
     // TODO: Support default arguments
+}
+
+impl<'gc, L> RuntimeFunction<L> {
+    pub fn alloc(self, alloc: &'gc Allocator) -> &'gc Self {
+        alloc.alloc(self)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/linefeed/src/vm/runtime_value/function.rs
+++ b/linefeed/src/vm/runtime_value/function.rs
@@ -9,7 +9,7 @@ pub struct RuntimeFunction<L = usize> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MemoizationKey {
+pub struct MemoizationKey<'gc> {
     pub func_location: usize,
-    pub args: Vec<RuntimeValue>,
+    pub args: Vec<RuntimeValue<'gc>>,
 }

--- a/linefeed/src/vm/runtime_value/iterator.rs
+++ b/linefeed/src/vm/runtime_value/iterator.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, rc::Rc};
 
 use crate::vm::runtime_value::{
-    counter::RuntimeCounter,
+    // counter::RuntimeCounter,
     list::RuntimeList,
     map::{MapIterator, RuntimeMap},
     number::RuntimeNumber,
@@ -12,14 +12,14 @@ use crate::vm::runtime_value::{
 };
 
 #[derive(Clone)]
-pub struct RuntimeIterator(Rc<RefCell<dyn Iterator<Item = RuntimeValue>>>);
+pub struct RuntimeIterator<'gc>(Rc<RefCell<dyn Iterator<Item = RuntimeValue<'gc>>>>);
 
-impl RuntimeIterator {
-    pub fn next(&self) -> Option<RuntimeValue> {
+impl<'gc> RuntimeIterator<'gc> {
+    pub fn next(&self) -> Option<RuntimeValue<'gc>> {
         self.0.borrow_mut().next()
     }
 
-    pub fn to_vec(&self) -> Vec<RuntimeValue> {
+    pub fn to_vec(&self) -> Vec<RuntimeValue<'gc>> {
         let mut out = Vec::new();
         while let Some(value) = self.next() {
             out.push(value);
@@ -28,13 +28,13 @@ impl RuntimeIterator {
     }
 }
 
-struct ListIterator {
-    list: RuntimeList,
+struct ListIterator<'gc> {
+    list: RuntimeList<'gc>,
     index: usize,
 }
 
-impl Iterator for ListIterator {
-    type Item = RuntimeValue;
+impl<'gc> Iterator for ListIterator<'gc> {
+    type Item = RuntimeValue<'gc>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let value = self.list.as_slice().get(self.index).cloned();
@@ -42,20 +42,20 @@ impl Iterator for ListIterator {
         value
     }
 }
+//
+// impl<'gc> From<RuntimeList<'gc>> for RuntimeIterator<'gc> {
+//     fn from(list: RuntimeList<'gc>) -> Self {
+//         Self(Rc::new(RefCell::new(ListIterator { list, index: 0 })))
+//     }
+// }
 
-impl From<RuntimeList> for RuntimeIterator {
-    fn from(list: RuntimeList) -> Self {
-        Self(Rc::new(RefCell::new(ListIterator { list, index: 0 })))
-    }
-}
-
-struct TupleIterator {
-    tuple: RuntimeTuple,
+struct TupleIterator<'gc> {
+    tuple: RuntimeTuple<'gc>,
     index: usize,
 }
 
-impl Iterator for TupleIterator {
-    type Item = RuntimeValue;
+impl<'gc> Iterator for TupleIterator<'gc> {
+    type Item = RuntimeValue<'gc>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let value = self.tuple.as_slice().get(self.index).cloned();
@@ -64,107 +64,108 @@ impl Iterator for TupleIterator {
     }
 }
 
-impl From<RuntimeTuple> for RuntimeIterator {
-    fn from(tuple: RuntimeTuple) -> Self {
-        Self(Rc::new(RefCell::new(TupleIterator { tuple, index: 0 })))
-    }
-}
+// impl<'gc> From<RuntimeTuple<'gc>> for RuntimeIterator<'gc> {
+//     fn from(tuple: RuntimeTuple) -> Self {
+//         Self(Rc::new(RefCell::new(TupleIterator { tuple, index: 0 })))
+//     }
+// }
 
-pub struct EnumeratedListIterator {
-    list: RuntimeList,
+pub struct EnumeratedListIterator<'gc> {
+    list: RuntimeList<'gc>,
     index: usize,
 }
 
-impl EnumeratedListIterator {
-    pub fn new(list: RuntimeList) -> Self {
+impl<'gc> EnumeratedListIterator<'gc> {
+    pub fn new(list: RuntimeList<'gc>) -> Self {
         Self { list, index: 0 }
     }
 }
 
-impl Iterator for EnumeratedListIterator {
-    type Item = RuntimeValue;
+impl<'gc> Iterator for EnumeratedListIterator<'gc> {
+    type Item = RuntimeValue<'gc>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let value = self.list.as_slice().get(self.index).cloned()?;
         let index_val = RuntimeValue::Num(RuntimeNumber::from(self.index));
-        let enumerated = RuntimeValue::Tuple(RuntimeTuple::from_vec(vec![index_val, value]));
+        let enumerated = todo!(); // RuntimeValue::Tuple(RuntimeTuple::from_vec(vec![index_val, value]));
         self.index += 1;
         Some(enumerated)
     }
 }
 
-impl From<EnumeratedListIterator> for RuntimeIterator {
-    fn from(iter: EnumeratedListIterator) -> Self {
-        Self(Rc::new(RefCell::new(iter)))
+impl<'gc> From<EnumeratedListIterator<'gc>> for RuntimeIterator<'gc> {
+    fn from(iter: EnumeratedListIterator<'gc>) -> Self {
+        todo!()
+        // Self(Rc::new(RefCell::new(iter)))
     }
 }
 
-impl From<RuntimeRange> for RuntimeIterator {
-    fn from(range: RuntimeRange) -> Self {
-        Self(Rc::new(RefCell::new(RangeIterator::new(range))))
-    }
-}
+// impl<'gc> From<RuntimeRange> for RuntimeIterator<'gc> {
+//     fn from(range: RuntimeRange) -> Self {
+//         Self(Rc::new(RefCell::new(RangeIterator::new(range))))
+//     }
+// }
 
-impl From<RuntimeString> for RuntimeIterator {
-    fn from(s: RuntimeString) -> Self {
-        Self::from(RuntimeList::from_vec(
-            s.as_str()
-                .chars()
-                .map(|c| RuntimeValue::Str(RuntimeString::new(c)))
-                .collect(),
-        ))
-    }
-}
+// impl<'gc> From<RuntimeString> for RuntimeIterator<'gc> {
+//     fn from(s: RuntimeString) -> Self {
+//         Self::from(RuntimeList::from_vec(
+//             s.as_str()
+//                 .chars()
+//                 .map(|c| RuntimeValue::Str(RuntimeString::new(c)))
+//                 .collect(),
+//         ))
+//     }
+// }
 
 pub struct EmptyIterator;
 
 impl Iterator for EmptyIterator {
-    type Item = RuntimeValue;
+    type Item = RuntimeValue<'static>;
 
     fn next(&mut self) -> Option<Self::Item> {
         None
     }
 }
 
-impl From<()> for RuntimeIterator {
+impl From<()> for RuntimeIterator<'static> {
     fn from(_: ()) -> Self {
         Self(Rc::new(RefCell::new(EmptyIterator)))
     }
 }
 
-impl From<RuntimeMap> for RuntimeIterator {
-    fn from(map: RuntimeMap) -> Self {
-        Self(Rc::new(RefCell::new(MapIterator::from(map))))
-    }
-}
+// impl<'gc> From<RuntimeMap<'gc>> for RuntimeIterator<'gc> {
+//     fn from(map: RuntimeMap) -> Self {
+//         Self(Rc::new(RefCell::new(MapIterator::from(map))))
+//     }
+// }
 
-impl From<RuntimeCounter> for RuntimeIterator {
-    fn from(map: RuntimeCounter) -> Self {
-        Self(Rc::new(RefCell::new(MapIterator::from(map))))
-    }
-}
+// impl From<RuntimeCounter> for RuntimeIterator {
+//     fn from(map: RuntimeCounter) -> Self {
+//         Self(Rc::new(RefCell::new(MapIterator::from(map))))
+//     }
+// }
 
-impl std::cmp::PartialEq for RuntimeIterator {
+impl std::cmp::PartialEq for RuntimeIterator<'_> {
     fn eq(&self, other: &Self) -> bool {
         Rc::ptr_eq(&self.0, &other.0)
     }
 }
 
-impl std::cmp::Eq for RuntimeIterator {}
+impl std::cmp::Eq for RuntimeIterator<'_> {}
 
-impl std::fmt::Debug for RuntimeIterator {
+impl std::fmt::Debug for RuntimeIterator<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "RuntimeIterator({:p})", self.0.as_ptr())
     }
 }
 
-impl std::fmt::Display for RuntimeIterator {
+impl std::fmt::Display for RuntimeIterator<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "<iterator@{:?}>", self.0.as_ptr())
     }
 }
 
-impl std::hash::Hash for RuntimeIterator {
+impl std::hash::Hash for RuntimeIterator<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.as_ptr().hash(state)
     }

--- a/linefeed/src/vm/runtime_value/iterator.rs
+++ b/linefeed/src/vm/runtime_value/iterator.rs
@@ -13,14 +13,12 @@ use crate::vm::runtime_value::{
     RuntimeValue,
 };
 
-#[derive(Clone)]
 pub struct RuntimeIterator<'gc>(RefCell<IteratorKind<'gc>>);
 
-#[derive(Clone)]
 enum IteratorKind<'gc> {
     // List(ListIterator<'gc>),
     Tuple(TupleIterator<'gc>),
-    // Range(RangeIterator),
+    Range(RangeIterator<'gc>),
     // Map(MapIterator<'gc>),
     // Counter(CounterIterator),
     Empty,
@@ -34,6 +32,7 @@ impl<'gc> RuntimeIterator<'gc> {
     pub fn next(&self) -> Option<RuntimeValue<'gc>> {
         match &mut *self.0.borrow_mut() {
             IteratorKind::Tuple(iter) => iter.next(),
+            IteratorKind::Range(iter) => iter.next(),
             IteratorKind::Empty => None,
         }
     }
@@ -49,6 +48,7 @@ impl<'gc> RuntimeIterator<'gc> {
     pub fn len(&self) -> usize {
         match &*self.0.borrow() {
             IteratorKind::Tuple(iter) => iter.tuple.len(),
+            IteratorKind::Range(iter) => iter.len().unwrap_or(usize::MAX),
             IteratorKind::Empty => 0,
         }
     }
@@ -128,11 +128,11 @@ impl<'gc> From<EnumeratedListIterator<'gc>> for RuntimeIterator<'gc> {
     }
 }
 
-// impl<'gc> From<RuntimeRange> for RuntimeIterator<'gc> {
-//     fn from(range: RuntimeRange) -> Self {
-//         Self(Rc::new(RefCell::new(RangeIterator::new(range))))
-//     }
-// }
+impl<'gc> From<RuntimeRange> for RuntimeIterator<'gc> {
+    fn from(range: RuntimeRange) -> Self {
+        Self(RefCell::new(IteratorKind::Range(RangeIterator::new(range))))
+    }
+}
 
 // impl<'gc> From<RuntimeString> for RuntimeIterator<'gc> {
 //     fn from(s: RuntimeString) -> Self {

--- a/linefeed/src/vm/runtime_value/iterator.rs
+++ b/linefeed/src/vm/runtime_value/iterator.rs
@@ -105,17 +105,17 @@ impl<'gc> EnumeratedListIterator<'gc> {
     }
 }
 
-impl<'gc> Iterator for EnumeratedListIterator<'gc> {
-    type Item = RuntimeValue<'gc>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let value = self.list.as_slice().get(self.index).cloned()?;
-        let index_val = RuntimeValue::Num(RuntimeNumber::from(self.index));
-        let enumerated = todo!(); // RuntimeValue::Tuple(RuntimeTuple::from_vec(vec![index_val, value]));
-        self.index += 1;
-        Some(enumerated)
-    }
-}
+// impl<'gc> Iterator for EnumeratedListIterator<'gc> {
+//     type Item = RuntimeValue<'gc>;
+//
+//     fn next(&mut self) -> Option<Self::Item> {
+//         let value = self.list.as_slice().get(self.index).cloned()?;
+//         let index_val = RuntimeValue::Num(RuntimeNumber::from(self.index));
+//         let enumerated = todo!(); // RuntimeValue::Tuple(RuntimeTuple::from_vec(vec![index_val, value]));
+//         self.index += 1;
+//         Some(enumerated)
+//     }
+// }
 
 impl<'gc> From<EnumeratedListIterator<'gc>> for RuntimeIterator<'gc> {
     fn from(iter: EnumeratedListIterator<'gc>) -> Self {

--- a/linefeed/src/vm/runtime_value/iterator.rs
+++ b/linefeed/src/vm/runtime_value/iterator.rs
@@ -1,13 +1,13 @@
-use std::{cell::RefCell, rc::Rc};
+use std::cell::RefCell;
 
 use oxc_allocator::{Allocator, Vec as AVec};
 
 use crate::vm::runtime_value::{
     list::RuntimeList,
-    map::{MapIterator, RuntimeMap},
+    map::MapIterator,
     number::RuntimeNumber,
     range::{RangeIterator, RuntimeRange},
-    string::{RuntimeString, StringIterator},
+    string::StringIterator,
     tuple::RuntimeTuple,
     // counter::RuntimeCounter,
     RuntimeValue,
@@ -164,7 +164,7 @@ impl<'gc> From<()> for RuntimeIterator<'gc> {
 
 impl<'gc> From<MapIterator<'gc>> for RuntimeIterator<'gc> {
     fn from(map_iter: MapIterator<'gc>) -> Self {
-        Self(RefCell::new(IteratorKind::Map(MapIterator::from(map_iter))))
+        Self(RefCell::new(IteratorKind::Map(map_iter)))
     }
 }
 

--- a/linefeed/src/vm/runtime_value/iterator.rs
+++ b/linefeed/src/vm/runtime_value/iterator.rs
@@ -27,6 +27,10 @@ enum IteratorKind<'gc> {
 }
 
 impl<'gc> RuntimeIterator<'gc> {
+    pub fn alloc(self, alloc: &'gc Allocator) -> &'gc Self {
+        alloc.alloc(self)
+    }
+
     pub fn next(&self) -> Option<RuntimeValue<'gc>> {
         match &mut *self.0.borrow_mut() {
             IteratorKind::Tuple(iter) => iter.next(),

--- a/linefeed/src/vm/runtime_value/iterator.rs
+++ b/linefeed/src/vm/runtime_value/iterator.rs
@@ -3,23 +3,25 @@ use std::{cell::RefCell, rc::Rc};
 use oxc_allocator::{Allocator, Vec as AVec};
 
 use crate::vm::runtime_value::{
-    // counter::RuntimeCounter,
     list::RuntimeList,
     map::{MapIterator, RuntimeMap},
     number::RuntimeNumber,
     range::{RangeIterator, RuntimeRange},
-    string::RuntimeString,
+    string::{RuntimeString, StringIterator},
     tuple::RuntimeTuple,
+    // counter::RuntimeCounter,
     RuntimeValue,
 };
 
 pub struct RuntimeIterator<'gc>(RefCell<IteratorKind<'gc>>);
 
 enum IteratorKind<'gc> {
-    // List(ListIterator<'gc>),
+    List(ListIterator<'gc>),
     Tuple(TupleIterator<'gc>),
     Range(RangeIterator<'gc>),
-    // Map(MapIterator<'gc>),
+    Map(MapIterator<'gc>),
+    Enumerated(EnumeratedListIterator<'gc>),
+    String(StringIterator<'gc>),
     // Counter(CounterIterator),
     Empty,
 }
@@ -29,17 +31,21 @@ impl<'gc> RuntimeIterator<'gc> {
         alloc.alloc(self)
     }
 
-    pub fn next(&self) -> Option<RuntimeValue<'gc>> {
+    pub fn next(&self, alloc: &'gc Allocator) -> Option<RuntimeValue<'gc>> {
         match &mut *self.0.borrow_mut() {
+            IteratorKind::List(iter) => iter.next(),
             IteratorKind::Tuple(iter) => iter.next(),
             IteratorKind::Range(iter) => iter.next(),
+            IteratorKind::Map(iter) => iter.next(alloc),
+            IteratorKind::Enumerated(iter) => iter.next(alloc),
+            IteratorKind::String(iter) => iter.next(),
             IteratorKind::Empty => None,
         }
     }
 
     pub fn to_vec(&self, alloc: &'gc Allocator) -> AVec<'gc, RuntimeValue<'gc>> {
         let mut out = AVec::with_capacity_in(self.len(), alloc);
-        while let Some(value) = self.next() {
+        while let Some(value) = self.next(alloc) {
             out.push(value);
         }
         out
@@ -47,15 +53,23 @@ impl<'gc> RuntimeIterator<'gc> {
 
     pub fn len(&self) -> usize {
         match &*self.0.borrow() {
+            IteratorKind::List(iter) => iter.list.len(),
             IteratorKind::Tuple(iter) => iter.tuple.len(),
             IteratorKind::Range(iter) => iter.len().unwrap_or(usize::MAX),
+            IteratorKind::Map(iter) => iter.len(),
+            IteratorKind::Enumerated(iter) => iter.list.len(),
+            IteratorKind::String(iter) => iter.chars.len(),
             IteratorKind::Empty => 0,
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 
 struct ListIterator<'gc> {
-    list: RuntimeList<'gc>,
+    list: &'gc RuntimeList<'gc>,
     index: usize,
 }
 
@@ -68,12 +82,15 @@ impl<'gc> Iterator for ListIterator<'gc> {
         value
     }
 }
-//
-// impl<'gc> From<RuntimeList<'gc>> for RuntimeIterator<'gc> {
-//     fn from(list: RuntimeList<'gc>) -> Self {
-//         Self(Rc::new(RefCell::new(ListIterator { list, index: 0 })))
-//     }
-// }
+
+impl<'gc> From<&'gc RuntimeList<'gc>> for RuntimeIterator<'gc> {
+    fn from(list: &'gc RuntimeList<'gc>) -> Self {
+        Self(RefCell::new(IteratorKind::List(ListIterator {
+            list,
+            index: 0,
+        })))
+    }
+}
 
 #[derive(Clone)]
 struct TupleIterator<'gc> {
@@ -99,32 +116,31 @@ impl<'gc> From<&'gc RuntimeTuple<'gc>> for RuntimeIterator<'gc> {
 }
 
 pub struct EnumeratedListIterator<'gc> {
-    list: RuntimeList<'gc>,
-    index: usize,
+    list: &'gc RuntimeList<'gc>,
+    index: isize,
 }
 
 impl<'gc> EnumeratedListIterator<'gc> {
-    pub fn new(list: RuntimeList<'gc>) -> Self {
+    pub fn new(list: &'gc RuntimeList<'gc>) -> Self {
         Self { list, index: 0 }
+    }
+
+    fn next(&mut self, alloc: &'gc Allocator) -> Option<RuntimeValue<'gc>> {
+        let value = self.list.as_slice().get(self.index as usize).cloned()?;
+        let index_val = RuntimeValue::Num(RuntimeNumber::from(self.index));
+
+        let pair_vec = AVec::from_iter_in([index_val, value], alloc);
+        let enumerated = RuntimeValue::Tuple(RuntimeTuple::from_vec(pair_vec).alloc(alloc));
+
+        self.index += 1;
+
+        Some(enumerated)
     }
 }
 
-// impl<'gc> Iterator for EnumeratedListIterator<'gc> {
-//     type Item = RuntimeValue<'gc>;
-//
-//     fn next(&mut self) -> Option<Self::Item> {
-//         let value = self.list.as_slice().get(self.index).cloned()?;
-//         let index_val = RuntimeValue::Num(RuntimeNumber::from(self.index));
-//         let enumerated = todo!(); // RuntimeValue::Tuple(RuntimeTuple::from_vec(vec![index_val, value]));
-//         self.index += 1;
-//         Some(enumerated)
-//     }
-// }
-
 impl<'gc> From<EnumeratedListIterator<'gc>> for RuntimeIterator<'gc> {
     fn from(iter: EnumeratedListIterator<'gc>) -> Self {
-        todo!()
-        // Self(Rc::new(RefCell::new(iter)))
+        Self(RefCell::new(IteratorKind::Enumerated(iter)))
     }
 }
 
@@ -134,16 +150,11 @@ impl<'gc> From<RuntimeRange> for RuntimeIterator<'gc> {
     }
 }
 
-// impl<'gc> From<RuntimeString> for RuntimeIterator<'gc> {
-//     fn from(s: RuntimeString) -> Self {
-//         Self::from(RuntimeList::from_vec(
-//             s.as_str()
-//                 .chars()
-//                 .map(|c| RuntimeValue::Str(RuntimeString::new(c)))
-//                 .collect(),
-//         ))
-//     }
-// }
+impl<'gc> From<StringIterator<'gc>> for RuntimeIterator<'gc> {
+    fn from(s: StringIterator<'gc>) -> Self {
+        Self(RefCell::new(IteratorKind::String(s)))
+    }
+}
 
 impl<'gc> From<()> for RuntimeIterator<'gc> {
     fn from(_: ()) -> Self {
@@ -151,11 +162,11 @@ impl<'gc> From<()> for RuntimeIterator<'gc> {
     }
 }
 
-// impl<'gc> From<RuntimeMap<'gc>> for RuntimeIterator<'gc> {
-//     fn from(map: RuntimeMap) -> Self {
-//         Self(Rc::new(RefCell::new(MapIterator::from(map))))
-//     }
-// }
+impl<'gc> From<MapIterator<'gc>> for RuntimeIterator<'gc> {
+    fn from(map_iter: MapIterator<'gc>) -> Self {
+        Self(RefCell::new(IteratorKind::Map(MapIterator::from(map_iter))))
+    }
+}
 
 // impl From<RuntimeCounter> for RuntimeIterator {
 //     fn from(map: RuntimeCounter) -> Self {

--- a/linefeed/src/vm/runtime_value/list.rs
+++ b/linefeed/src/vm/runtime_value/list.rs
@@ -1,6 +1,6 @@
 use std::cell::{Ref, RefCell};
 
-use oxc_allocator::{Allocator, CloneIn, Vec as AVec};
+use oxc_allocator::{Allocator, Vec as AVec};
 use rustc_hash::FxHashMap;
 
 use crate::vm::{

--- a/linefeed/src/vm/runtime_value/list.rs
+++ b/linefeed/src/vm/runtime_value/list.rs
@@ -140,7 +140,7 @@ impl<'gc> RuntimeList<'gc> {
 }
 
 impl<'old, 'new> oxc_allocator::CloneIn<'new> for RuntimeList<'old> {
-    type Cloned = &'new RuntimeList<'new>;
+    type Cloned = RuntimeList<'new>;
 
     fn clone_in(&self, alloc: &'new Allocator) -> Self::Cloned {
         let cloned = self.as_slice().iter().map(|v| v.clone_in(alloc)).fold(
@@ -151,7 +151,7 @@ impl<'old, 'new> oxc_allocator::CloneIn<'new> for RuntimeList<'old> {
             },
         );
 
-        alloc.alloc(RuntimeList::from_vec(cloned))
+        RuntimeList::from_vec(cloned)
     }
 }
 

--- a/linefeed/src/vm/runtime_value/map.rs
+++ b/linefeed/src/vm/runtime_value/map.rs
@@ -52,20 +52,20 @@ impl<'gc> RuntimeMap<'gc> {
         self.0.borrow_mut()
     }
 
-    pub fn deep_clone(&self) -> Self {
-        let new_map = Self::from_map(
-            self.borrow()
-                .iter()
-                .map(|(k, v)| (k.deep_clone(), v.deep_clone()))
-                .collect(),
-        );
-
-        if let Some(default_value) = &self.borrow().default_value {
-            new_map.borrow_mut().default_value = Some(default_value.deep_clone());
-        }
-
-        new_map
-    }
+    // pub fn deep_clone(&self) -> Self {
+    //     let new_map = Self::from_map(
+    //         self.borrow()
+    //             .iter()
+    //             .map(|(k, v)| (k.deep_clone(), v.deep_clone()))
+    //             .collect(),
+    //     );
+    //
+    //     if let Some(default_value) = &self.borrow().default_value {
+    //         new_map.borrow_mut().default_value = Some(default_value.deep_clone());
+    //     }
+    //
+    //     new_map
+    // }
 
     pub fn get(&self, key: &RuntimeValue<'gc>) -> RuntimeValue<'gc> {
         self.insert_default_value_if_missing(key);
@@ -90,7 +90,8 @@ impl<'gc> RuntimeMap<'gc> {
         };
 
         if !self.borrow().contains_key(key) {
-            self.insert(key.clone(), default_value.deep_clone());
+            todo!()
+            // self.insert(key.clone(), default_value.deep_clone());
         }
     }
 }

--- a/linefeed/src/vm/runtime_value/map.rs
+++ b/linefeed/src/vm/runtime_value/map.rs
@@ -1,14 +1,10 @@
-use std::{cell::RefCell, mem::ManuallyDrop, ops::Deref, rc::Rc};
+use std::{cell::RefCell, ops::Deref};
 
 use oxc_allocator::{Allocator, Box as ABox, CloneIn, HashMap as AHashMap, Vec as AVec};
-use rustc_hash::FxHashMap;
 
-use crate::vm::{
-    runtime_value::{
-        iterator::RuntimeIterator, number::RuntimeNumber, tuple::RuntimeTuple, RuntimeValue,
-    },
-    RuntimeError,
-};
+use crate::vm::runtime_value::{
+        tuple::RuntimeTuple, RuntimeValue,
+    };
 
 #[derive(Debug)]
 pub struct RuntimeMap<'gc>(RefCell<InnerRuntimeMap<'gc>>);

--- a/linefeed/src/vm/runtime_value/number.rs
+++ b/linefeed/src/vm/runtime_value/number.rs
@@ -38,7 +38,7 @@ impl<'gc> RuntimeNumber<'gc> {
     pub fn floor(&self) -> Self {
         match self {
             SmallInt(i) => SmallInt(*i),
-            BigInt(i) => BigInt(*i),
+            BigInt(i) => BigInt(i),
             Float(f) => Float(f.floor()),
         }
     }

--- a/linefeed/src/vm/runtime_value/number.rs
+++ b/linefeed/src/vm/runtime_value/number.rs
@@ -256,6 +256,18 @@ impl PartialEq for RuntimeNumber<'_> {
     }
 }
 
+impl<'old, 'new> oxc_allocator::CloneIn<'new> for RuntimeNumber<'old> {
+    type Cloned = RuntimeNumber<'new>;
+
+    fn clone_in(&self, alloc: &'new Allocator) -> Self::Cloned {
+        match self {
+            SmallInt(i) => SmallInt(*i),
+            BigInt(i) => BigInt(rug::Integer::from(*i).alloc(alloc)),
+            Float(f) => Float(*f),
+        }
+    }
+}
+
 use crate::vm::RuntimeError;
 
 // Fuck it, we ball

--- a/linefeed/src/vm/runtime_value/operations.rs
+++ b/linefeed/src/vm/runtime_value/operations.rs
@@ -1,5 +1,5 @@
 use crate::vm::{runtime_value::RuntimeValue, RuntimeError};
 
-pub trait LfAppend {
-    fn append(&mut self, other: RuntimeValue) -> Result<(), RuntimeError>;
+pub trait LfAppend<'gc> {
+    fn append(&mut self, other: RuntimeValue<'gc>) -> Result<(), RuntimeError>;
 }

--- a/linefeed/src/vm/runtime_value/operations.rs
+++ b/linefeed/src/vm/runtime_value/operations.rs
@@ -1,5 +1,0 @@
-use crate::vm::{runtime_value::RuntimeValue, RuntimeError};
-
-pub trait LfAppend<'gc> {
-    fn append(&mut self, other: RuntimeValue<'gc>) -> Result<(), RuntimeError>;
-}

--- a/linefeed/src/vm/runtime_value/range.rs
+++ b/linefeed/src/vm/runtime_value/range.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use crate::vm::runtime_value::{number::RuntimeNumber, RuntimeValue};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -48,24 +50,26 @@ impl std::fmt::Display for RuntimeRange {
     }
 }
 
-pub struct RangeIterator {
+pub struct RangeIterator<'gc> {
     range: RuntimeRange,
     value: isize,
     step: isize,
+    phantom: PhantomData<&'gc ()>,
 }
 
-impl RangeIterator {
+impl<'gc> RangeIterator<'gc> {
     pub fn new(range: RuntimeRange) -> Self {
         Self {
             value: range.start.unwrap_or(0),
             step: if range.is_reverse() { -1 } else { 1 },
             range,
+            phantom: PhantomData,
         }
     }
 }
 
-impl Iterator for RangeIterator {
-    type Item = RuntimeValue;
+impl<'gc> Iterator for RangeIterator<'gc> {
+    type Item = RuntimeValue<'gc>;
 
     fn next(&mut self) -> Option<Self::Item> {
         debug_assert!(self.step.abs() == 1);

--- a/linefeed/src/vm/runtime_value/range.rs
+++ b/linefeed/src/vm/runtime_value/range.rs
@@ -72,6 +72,16 @@ impl<'gc> RangeIterator<'gc> {
             phantom: PhantomData,
         }
     }
+
+    pub fn len(&self) -> Option<usize> {
+        match (self.range.start, self.range.end) {
+            (Some(start), Some(end)) => {
+                let dist = start.abs_diff(end);
+                Some(dist / self.step.abs() as usize)
+            }
+            _ => None,
+        }
+    }
 }
 
 impl<'gc> Iterator for RangeIterator<'gc> {

--- a/linefeed/src/vm/runtime_value/range.rs
+++ b/linefeed/src/vm/runtime_value/range.rs
@@ -18,7 +18,7 @@ impl RuntimeRange {
         }
     }
 
-    pub fn alloc<'gc>(self, alloc: &'gc Allocator) -> &'gc Self {
+    pub fn alloc(self, alloc: &Allocator) -> &Self {
         alloc.alloc(self)
     }
 
@@ -77,7 +77,7 @@ impl<'gc> RangeIterator<'gc> {
         match (self.range.start, self.range.end) {
             (Some(start), Some(end)) => {
                 let dist = start.abs_diff(end);
-                Some(dist / self.step.abs() as usize)
+                Some(dist / self.step.unsigned_abs())
             }
             _ => None,
         }

--- a/linefeed/src/vm/runtime_value/range.rs
+++ b/linefeed/src/vm/runtime_value/range.rs
@@ -1,5 +1,7 @@
 use std::marker::PhantomData;
 
+use oxc_allocator::Allocator;
+
 use crate::vm::runtime_value::{number::RuntimeNumber, RuntimeValue};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -14,6 +16,10 @@ impl RuntimeRange {
             start: start.map(|n| n.floor_int()),
             end: end.map(|n| n.floor_int()),
         }
+    }
+
+    pub fn alloc<'gc>(self, alloc: &'gc Allocator) -> &'gc Self {
+        alloc.alloc(self)
     }
 
     pub fn is_reverse(&self) -> bool {

--- a/linefeed/src/vm/runtime_value/regex.rs
+++ b/linefeed/src/vm/runtime_value/regex.rs
@@ -50,15 +50,14 @@ impl<'gc> RuntimeRegex {
         self.0.regex.as_str()
     }
 
-    pub fn find_matches(&self, s: &RuntimeString, alloc: &'gc Allocator) -> RuntimeList<'gc> {
+    pub fn find_matches(&self, s: &RuntimeString, alloc: &'gc Allocator) -> &'gc RuntimeList<'gc> {
         let matches = self
             .0
             .regex
             .captures_iter(s.as_str())
-            .map(|m| self.process_capture(m, alloc))
-            .collect::<Vec<_>>();
+            .map(|m| self.process_capture(m, alloc));
 
-        RuntimeList::from_vec(matches)
+        RuntimeList::from_vec(AVec::from_iter_in(matches, alloc)).alloc(alloc)
     }
 
     pub fn find_match(&self, s: &RuntimeString, alloc: &'gc Allocator) -> RuntimeValue<'gc> {
@@ -101,7 +100,7 @@ impl<'gc> RuntimeRegex {
         let full_match = group_values.remove(0);
         group_values.push(full_match);
 
-        RuntimeValue::Tuple(alloc.alloc(RuntimeTuple::from_vec(group_values)))
+        RuntimeValue::Tuple(RuntimeTuple::from_vec(group_values).alloc(alloc))
     }
 }
 

--- a/linefeed/src/vm/runtime_value/regex.rs
+++ b/linefeed/src/vm/runtime_value/regex.rs
@@ -1,4 +1,4 @@
-use std::{mem::ManuallyDrop, rc::Rc};
+use std::mem::ManuallyDrop;
 
 use oxc_allocator::{Allocator, Vec as AVec};
 use regex::{Regex, RegexBuilder};

--- a/linefeed/src/vm/runtime_value/regex.rs
+++ b/linefeed/src/vm/runtime_value/regex.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use oxc_allocator::Allocator;
+use oxc_allocator::{Allocator, Vec as AVec};
 use regex::{Regex, RegexBuilder};
 
 use crate::vm::runtime_value::{
@@ -91,7 +91,10 @@ impl<'gc> RuntimeRegex {
                     RuntimeValue::Str(RuntimeString::new(g.as_str()))
                 })
             })
-            .collect::<Vec<_>>();
+            .fold(AVec::with_capacity_in(captures.len(), alloc), |mut f, v| {
+                f.push(v);
+                f
+            });
 
         // The full match is almost never useful, so just put it at the end, enabling the user
         // to just ignore it if they don't need it.

--- a/linefeed/src/vm/runtime_value/set.rs
+++ b/linefeed/src/vm/runtime_value/set.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use rustc_hash::FxHashSet;
 
 use crate::vm::{
-    runtime_value::{iterator::RuntimeIterator, operations::LfAppend, RuntimeValue},
+    runtime_value::{iterator::RuntimeIterator, RuntimeValue},
     RuntimeError,
 };
 
@@ -21,6 +21,11 @@ impl<'gc> RuntimeSet<'gc> {
 
     pub fn borrow(&self) -> std::cell::Ref<'_, FxHashSet<RuntimeValue<'gc>>> {
         self.0.borrow()
+    }
+
+    pub fn append(&self, other: RuntimeValue<'gc>) -> Result<(), RuntimeError> {
+        self.0.borrow_mut().insert(other);
+        Ok(())
     }
 
     pub fn len(&self) -> usize {
@@ -96,12 +101,5 @@ impl std::cmp::PartialOrd for RuntimeSet<'_> {
         let a = self.0.borrow();
         let b = other.0.borrow();
         a.len().partial_cmp(&b.len())
-    }
-}
-
-impl<'gc> LfAppend<'gc> for RuntimeSet<'gc> {
-    fn append(&mut self, other: RuntimeValue<'gc>) -> Result<(), RuntimeError> {
-        self.0.borrow_mut().insert(other);
-        Ok(())
     }
 }

--- a/linefeed/src/vm/runtime_value/string.rs
+++ b/linefeed/src/vm/runtime_value/string.rs
@@ -1,4 +1,3 @@
-use std::rc::Rc;
 
 use oxc_allocator::{Allocator, Vec as AVec};
 
@@ -30,7 +29,7 @@ impl<'gc> RuntimeString<'gc> {
     }
 
     pub fn as_str(&self) -> &str {
-        &self.0
+        self.0
     }
 
     pub fn len(&self) -> usize {

--- a/linefeed/src/vm/runtime_value/string.rs
+++ b/linefeed/src/vm/runtime_value/string.rs
@@ -67,7 +67,7 @@ impl<'gc> RuntimeString {
         Self::new(format!("{}{}", self.as_str(), other.as_str()))
     }
 
-    pub fn count(&self, substr: &RuntimeString) -> RuntimeNumber {
+    pub fn count(&self, substr: &RuntimeString) -> RuntimeNumber<'gc> {
         let n = self.as_str().matches(substr.as_str()).count();
         RuntimeNumber::from(n as isize)
     }

--- a/linefeed/src/vm/runtime_value/string.rs
+++ b/linefeed/src/vm/runtime_value/string.rs
@@ -14,7 +14,7 @@ use crate::vm::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct RuntimeString(Rc<String>);
 
-impl RuntimeString {
+impl<'gc> RuntimeString {
     pub fn new(s: impl Into<String>) -> Self {
         Self(Rc::new(s.into()))
     }
@@ -43,7 +43,7 @@ impl RuntimeString {
         self.map_str(|s| s.to_uppercase())
     }
 
-    pub fn split(&self, delimiter: &RuntimeString) -> RuntimeList {
+    pub fn split(&self, delimiter: &RuntimeString) -> RuntimeList<'gc> {
         let parts = self
             .as_str()
             .split(delimiter.as_str())
@@ -53,7 +53,7 @@ impl RuntimeString {
         RuntimeList::from_vec(parts)
     }
 
-    pub fn lines(&self) -> RuntimeList {
+    pub fn lines(&self) -> RuntimeList<'gc> {
         let parts = self
             .as_str()
             .lines()

--- a/linefeed/src/vm/runtime_value/string.rs
+++ b/linefeed/src/vm/runtime_value/string.rs
@@ -1,5 +1,7 @@
 use std::rc::Rc;
 
+use oxc_allocator::{Allocator, Vec as AVec};
+
 use crate::vm::{
     runtime_value::{
         list::RuntimeList,
@@ -43,24 +45,22 @@ impl<'gc> RuntimeString {
         self.map_str(|s| s.to_uppercase())
     }
 
-    pub fn split(&self, delimiter: &RuntimeString) -> RuntimeList<'gc> {
+    pub fn split(&self, delimiter: &RuntimeString, alloc: &'gc Allocator) -> &'gc RuntimeList<'gc> {
         let parts = self
             .as_str()
             .split(delimiter.as_str())
-            .map(|s| RuntimeValue::Str(Self::new(s)))
-            .collect();
+            .map(|s| RuntimeValue::Str(Self::new(s)));
 
-        RuntimeList::from_vec(parts)
+        RuntimeList::from_vec(AVec::from_iter_in(parts, alloc)).alloc(alloc)
     }
 
-    pub fn lines(&self) -> RuntimeList<'gc> {
+    pub fn lines(&self, alloc: &'gc Allocator) -> &'gc RuntimeList<'gc> {
         let parts = self
             .as_str()
             .lines()
-            .map(|s| RuntimeValue::Str(Self::new(s)))
-            .collect();
+            .map(|s| RuntimeValue::Str(Self::new(s)));
 
-        RuntimeList::from_vec(parts)
+        RuntimeList::from_vec(AVec::from_iter_in(parts, alloc)).alloc(alloc)
     }
 
     pub fn concat(&self, other: &RuntimeString) -> Self {

--- a/linefeed/src/vm/runtime_value/string.rs
+++ b/linefeed/src/vm/runtime_value/string.rs
@@ -14,11 +14,19 @@ use crate::vm::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RuntimeString(Rc<String>);
+pub struct RuntimeString<'gc>(&'gc str);
 
-impl<'gc> RuntimeString {
-    pub fn new(s: impl Into<String>) -> Self {
-        Self(Rc::new(s.into()))
+impl<'gc> RuntimeString<'gc> {
+    pub fn from_str(s: &'gc str) -> Self {
+        Self(s)
+    }
+
+    pub fn alloc_from_str(s: impl AsRef<str>, alloc: &'gc Allocator) -> &'gc Self {
+        Self(alloc.alloc_str(s.as_ref())).alloc(alloc)
+    }
+
+    pub fn alloc(self, alloc: &'gc Allocator) -> &'gc Self {
+        alloc.alloc(self)
     }
 
     pub fn as_str(&self) -> &str {
@@ -33,23 +41,27 @@ impl<'gc> RuntimeString {
         self.0.is_empty()
     }
 
-    fn map_str(&self, f: impl FnOnce(&str) -> String) -> Self {
-        Self::new(f(self.as_str()))
+    fn map_str<A: AsRef<str>>(
+        &self,
+        f: impl FnOnce(&str) -> A,
+        alloc: &'gc Allocator,
+    ) -> &'gc Self {
+        Self::alloc_from_str(f(self.as_str()), alloc)
     }
 
-    pub fn to_lowercase(&self) -> Self {
-        self.map_str(|s| s.to_lowercase())
+    pub fn to_lowercase(&self, alloc: &'gc Allocator) -> &'gc Self {
+        self.map_str(|s| s.to_lowercase(), alloc)
     }
 
-    pub fn to_uppercase(&self) -> Self {
-        self.map_str(|s| s.to_uppercase())
+    pub fn to_uppercase(&self, alloc: &'gc Allocator) -> &'gc Self {
+        self.map_str(|s| s.to_uppercase(), alloc)
     }
 
     pub fn split(&self, delimiter: &RuntimeString, alloc: &'gc Allocator) -> &'gc RuntimeList<'gc> {
         let parts = self
             .as_str()
             .split(delimiter.as_str())
-            .map(|s| RuntimeValue::Str(Self::new(s)));
+            .map(|s| RuntimeValue::Str(Self::alloc_from_str(s, alloc)));
 
         RuntimeList::from_vec(AVec::from_iter_in(parts, alloc)).alloc(alloc)
     }
@@ -58,13 +70,13 @@ impl<'gc> RuntimeString {
         let parts = self
             .as_str()
             .lines()
-            .map(|s| RuntimeValue::Str(Self::new(s)));
+            .map(|s| RuntimeValue::Str(Self::alloc_from_str(s, alloc)));
 
         RuntimeList::from_vec(AVec::from_iter_in(parts, alloc)).alloc(alloc)
     }
 
-    pub fn concat(&self, other: &RuntimeString) -> Self {
-        Self::new(format!("{}{}", self.as_str(), other.as_str()))
+    pub fn concat(&self, other: impl AsRef<str>, alloc: &'gc Allocator) -> &'gc Self {
+        Self::from_str(alloc.alloc_concat_strs_array([self.as_str(), other.as_ref()])).alloc(alloc)
     }
 
     pub fn count(&self, substr: &RuntimeString) -> RuntimeNumber<'gc> {
@@ -72,7 +84,11 @@ impl<'gc> RuntimeString {
         RuntimeNumber::from(n as isize)
     }
 
-    pub fn index(&self, index: &RuntimeNumber) -> Result<RuntimeString, RuntimeError> {
+    pub fn index(
+        &self,
+        index: &RuntimeNumber,
+        alloc: &'gc Allocator,
+    ) -> Result<&'gc Self, RuntimeError> {
         let i = resolve_index(self.len(), index)?;
 
         // Not quite the best for Rust's UTF-8 strings, but all inputs for Linefeed's use-cases
@@ -84,21 +100,31 @@ impl<'gc> RuntimeString {
             ))
         })?;
 
-        Ok(Self::new(char::from(*byte)))
+        Ok(Self::alloc_from_str(char::from(*byte).to_string(), alloc))
     }
 
     pub fn contains(&self, substr: &RuntimeString) -> bool {
         self.as_str().contains(substr.as_str())
     }
 
-    pub fn substr(&self, range: &RuntimeRange) -> Result<Self, RuntimeError> {
+    pub fn substr(
+        &self,
+        range: &RuntimeRange,
+        alloc: &'gc Allocator,
+    ) -> Result<&'gc Self, RuntimeError> {
         let (start, end) = resolve_slice_indices(self.len(), range)?;
-        Ok(Self::new(&self.as_str()[start..end + 1]))
+        Ok(Self::alloc_from_str(&self.as_str()[start..end + 1], alloc))
     }
 }
 
-impl std::fmt::Display for RuntimeString {
+impl std::fmt::Display for RuntimeString<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.as_str())
+    }
+}
+
+impl AsRef<str> for RuntimeString<'_> {
+    fn as_ref(&self) -> &str {
+        self.as_str()
     }
 }

--- a/linefeed/src/vm/runtime_value/tuple.rs
+++ b/linefeed/src/vm/runtime_value/tuple.rs
@@ -21,6 +21,10 @@ impl<'gc> RuntimeTuple<'gc> {
         Self(vec)
     }
 
+    pub fn alloc(self, alloc: &'gc Allocator) -> &'gc Self {
+        alloc.alloc(self)
+    }
+
     pub fn as_slice(&self) -> &[RuntimeValue<'gc>] {
         self.0.as_slice()
     }

--- a/linefeed/src/vm/runtime_value/tuple.rs
+++ b/linefeed/src/vm/runtime_value/tuple.rs
@@ -1,44 +1,55 @@
-use std::rc::Rc;
+use std::cell::{Ref, RefCell};
+
+use oxc_allocator::Allocator;
 
 use crate::vm::{
     runtime_value::{number::RuntimeNumber, utils::resolve_index, RuntimeValue},
     RuntimeError,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
-pub struct RuntimeTuple(Rc<Vec<RuntimeValue>>);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
+// TODO: just use cell
+pub struct RuntimeTuple<'gc>(RefCell<Vec<RuntimeValue<'gc>>>);
 
-impl RuntimeTuple {
-    pub fn from_vec(vec: Vec<RuntimeValue>) -> Self {
-        Self(Rc::new(vec))
+impl<'gc> RuntimeTuple<'gc> {
+    pub fn from_vec(vec: Vec<RuntimeValue<'gc>>) -> Self {
+        Self(RefCell::new(vec))
     }
 
-    pub fn as_slice(&self) -> &[RuntimeValue] {
-        self.0.as_slice()
+    pub fn as_slice(&self) -> Ref<'_, [RuntimeValue<'gc>]> {
+        Ref::map(self.0.borrow(), |v| v.as_slice())
+    }
+
+    pub fn borrow(&self) -> Ref<'_, Vec<RuntimeValue<'gc>>> {
+        self.0.borrow()
     }
 
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.borrow().len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.borrow().is_empty()
     }
 
-    pub fn index(&self, index: &RuntimeNumber) -> Result<RuntimeValue, RuntimeError> {
+    pub fn index(&self, index: &RuntimeNumber) -> Result<RuntimeValue<'gc>, RuntimeError> {
         let i = resolve_index(self.len(), index)?;
 
-        self.0
+        self.borrow()
             .get(i)
             .cloned()
             .ok_or_else(|| RuntimeError::IndexOutOfBounds(i as isize, self.len()))
     }
 
-    pub fn contains(&self, value: &RuntimeValue) -> bool {
-        self.0.iter().any(|v| v == value)
+    pub fn contains(&self, value: &RuntimeValue<'gc>) -> bool {
+        self.borrow().iter().any(|v| v == value)
     }
 
-    pub fn element_wise_add(&self, other: &Self) -> Result<Self, RuntimeError> {
+    pub fn element_wise_add(
+        &self,
+        other: &Self,
+        alloc: &'gc Allocator,
+    ) -> Result<&Self, RuntimeError> {
         if self.len() != other.len() {
             return Err(RuntimeError::TypeMismatch(format!(
                 "Cannot add tuples of different lengths: {} and {}",
@@ -47,20 +58,37 @@ impl RuntimeTuple {
             )));
         }
 
-        let result: Result<Vec<RuntimeValue>, RuntimeError> = self
-            .0
+        let result: Result<Vec<RuntimeValue<'gc>>, RuntimeError> = self
+            .borrow()
             .iter()
-            .zip(other.0.iter())
-            .map(|(a, b)| a.add(b))
+            .zip(other.borrow().iter())
+            .map(|(a, b)| a.add(b, alloc))
             .collect();
 
-        Ok(RuntimeTuple::from_vec(result?))
+        let tup = alloc.alloc(RuntimeTuple::from_vec(result?));
+
+        Ok(tup)
     }
 
-    pub fn scalar_multiply(&self, scalar: &RuntimeValue) -> Result<Self, RuntimeError> {
-        let result: Result<Vec<RuntimeValue>, RuntimeError> =
-            self.0.iter().map(|elem| elem.mul(scalar)).collect();
+    pub fn scalar_multiply(
+        &self,
+        scalar: &RuntimeValue<'gc>,
+        alloc: &'gc Allocator,
+    ) -> Result<&Self, RuntimeError> {
+        let result: Result<Vec<RuntimeValue<'gc>>, RuntimeError> = self
+            .borrow()
+            .iter()
+            .map(|elem| elem.mul(scalar, alloc))
+            .collect();
 
-        Ok(RuntimeTuple::from_vec(result?))
+        Ok(alloc.alloc(RuntimeTuple::from_vec(result?)))
+    }
+}
+
+impl std::hash::Hash for RuntimeTuple<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for item in self.borrow().iter() {
+            item.hash(state);
+        }
     }
 }

--- a/linefeed/src/vm/runtime_value/tuple.rs
+++ b/linefeed/src/vm/runtime_value/tuple.rs
@@ -94,6 +94,22 @@ impl<'gc> RuntimeTuple<'gc> {
     }
 }
 
+impl<'old, 'new> oxc_allocator::CloneIn<'new> for RuntimeTuple<'old> {
+    type Cloned = RuntimeTuple<'new>;
+
+    fn clone_in(&self, alloc: &'new Allocator) -> Self::Cloned {
+        let cloned = self.as_slice().iter().map(|v| v.clone_in(alloc)).fold(
+            AVec::with_capacity_in(self.len(), alloc),
+            |mut acc, v| {
+                acc.push(v);
+                acc
+            },
+        );
+
+        RuntimeTuple::from_vec(cloned)
+    }
+}
+
 impl std::cmp::PartialOrd for RuntimeTuple<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         let a = self.as_slice();

--- a/linefeed/src/vm/stdlib.rs
+++ b/linefeed/src/vm/stdlib.rs
@@ -25,7 +25,10 @@ pub fn parse_int(val: RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
     Ok(res)
 }
 
-pub fn to_list(val: RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
+pub fn to_list<'gc>(
+    val: RuntimeValue<'gc>,
+    alloc: &'gc Allocator,
+) -> Result<RuntimeValue<'gc>, RuntimeError> {
     if let RuntimeValue::List(_) = val {
         return Ok(val.clone());
     }
@@ -37,7 +40,10 @@ pub fn to_list(val: RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
         )));
     };
 
-    Ok(RuntimeValue::List(RuntimeList::from_vec(iter.to_vec())))
+    todo!()
+    // Ok(RuntimeValue::List(RuntimeList::from_vec(
+    //     iter.to_vec(alloc),
+    // )))
 }
 
 pub fn to_tuple<'gc>(
@@ -56,7 +62,7 @@ pub fn to_tuple<'gc>(
     };
 
     Ok(RuntimeValue::Tuple(
-        alloc.alloc(RuntimeTuple::from_vec(iter.to_vec())),
+        alloc.alloc(RuntimeTuple::from_vec(iter.to_vec(alloc))),
     ))
 }
 

--- a/linefeed/src/vm/stdlib.rs
+++ b/linefeed/src/vm/stdlib.rs
@@ -66,10 +66,13 @@ pub fn to_tuple<'gc>(
     ))
 }
 
-pub fn map_with_default(default_value: RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
-    Ok(RuntimeValue::Map(RuntimeMap::new_with_default_value(
-        default_value,
-    )))
+pub fn map_with_default<'gc>(
+    default_value: RuntimeValue<'gc>,
+    alloc: &'gc Allocator,
+) -> Result<RuntimeValue<'gc>, RuntimeError> {
+    Ok(RuntimeValue::Map(
+        RuntimeMap::new_with_default_value(default_value, alloc).alloc(alloc),
+    ))
 }
 
 pub fn to_map<'gc>(val: RuntimeValue<'gc>) -> Result<RuntimeValue<'gc>, RuntimeError> {

--- a/linefeed/src/vm/stdlib.rs
+++ b/linefeed/src/vm/stdlib.rs
@@ -2,8 +2,8 @@ use oxc_allocator::Allocator;
 
 use crate::vm::{
     runtime_value::{
-        iterator::RuntimeIterator, list::RuntimeList, map::RuntimeMap, number::RuntimeNumber,
-        set::RuntimeSet, tuple::RuntimeTuple, RuntimeValue,
+        list::RuntimeList, map::RuntimeMap, number::RuntimeNumber, tuple::RuntimeTuple,
+        RuntimeValue,
     },
     RuntimeError,
 };

--- a/linefeed/src/vm/stdlib.rs
+++ b/linefeed/src/vm/stdlib.rs
@@ -33,7 +33,7 @@ pub fn to_list<'gc>(
         return Ok(val.clone());
     }
 
-    let Ok(RuntimeValue::Iterator(iter)) = val.to_iter() else {
+    let Ok(RuntimeValue::Iterator(iter)) = val.to_iter(alloc) else {
         return Err(RuntimeError::TypeMismatch(format!(
             "Cannot convert type {} to a list",
             val.kind_str()
@@ -54,7 +54,7 @@ pub fn to_tuple<'gc>(
         return Ok(val.clone());
     }
 
-    let Ok(RuntimeValue::Iterator(iter)) = val.to_iter() else {
+    let Ok(RuntimeValue::Iterator(iter)) = val.to_iter(alloc) else {
         return Err(RuntimeError::TypeMismatch(format!(
             "Cannot convert type {} to a tuple",
             val.kind_str()
@@ -75,12 +75,15 @@ pub fn map_with_default<'gc>(
     ))
 }
 
-pub fn to_map<'gc>(val: RuntimeValue<'gc>) -> Result<RuntimeValue<'gc>, RuntimeError> {
+pub fn to_map<'gc>(
+    val: RuntimeValue<'gc>,
+    alloc: &'gc Allocator,
+) -> Result<RuntimeValue<'gc>, RuntimeError> {
     if let RuntimeValue::Map(_) = val {
         return Ok(val.clone());
     }
 
-    let Ok(RuntimeValue::Iterator(iter)) = val.to_iter() else {
+    let Ok(RuntimeValue::Iterator(iter)) = val.to_iter(alloc) else {
         return Err(RuntimeError::TypeMismatch(format!(
             "Cannot convert type {} to a map",
             val.kind_str()
@@ -91,12 +94,15 @@ pub fn to_map<'gc>(val: RuntimeValue<'gc>) -> Result<RuntimeValue<'gc>, RuntimeE
     // Ok(RuntimeValue::Map(RuntimeMap::try_from(*iter)?))
 }
 
-pub fn to_set<'gc>(val: Option<RuntimeValue<'gc>>) -> Result<RuntimeValue<'gc>, RuntimeError> {
+pub fn to_set<'gc>(
+    val: Option<RuntimeValue<'gc>>,
+    alloc: &'gc Allocator,
+) -> Result<RuntimeValue<'gc>, RuntimeError> {
     if let Some(RuntimeValue::Set(_)) = val {
         return Ok(val.unwrap().clone());
     }
 
-    let Some(Ok(iter)) = val.as_ref().map(|v| v.to_iter()) else {
+    let Some(Ok(iter)) = val.as_ref().map(|v| v.to_iter(alloc)) else {
         return Err(RuntimeError::TypeMismatch(format!(
             "Cannot convert type {} to a set",
             val.unwrap().kind_str()
@@ -123,7 +129,7 @@ pub fn to_set<'gc>(val: Option<RuntimeValue<'gc>>) -> Result<RuntimeValue<'gc>, 
 // }
 
 pub fn sum<'gc>(val: RuntimeValue<'gc>, alloc: &'gc Allocator) -> RuntimeResult<'gc> {
-    let Ok(RuntimeValue::Iterator(iter)) = val.to_iter() else {
+    let Ok(RuntimeValue::Iterator(iter)) = val.to_iter(alloc) else {
         return Err(RuntimeError::TypeMismatch(format!(
             "Cannot sum over type {}",
             val.kind_str()
@@ -139,7 +145,7 @@ pub fn sum<'gc>(val: RuntimeValue<'gc>, alloc: &'gc Allocator) -> RuntimeResult<
 }
 
 pub fn mul<'gc>(val: RuntimeValue<'gc>, alloc: &'gc Allocator) -> RuntimeResult<'gc> {
-    let Ok(RuntimeValue::Iterator(iter)) = val.to_iter() else {
+    let Ok(RuntimeValue::Iterator(iter)) = val.to_iter(alloc) else {
         return Err(RuntimeError::TypeMismatch(format!(
             "Cannot multiply over type {}",
             val.kind_str()


### PR DESCRIPTION
This took a **lot** of effort (~2 days). The main idea was:
- Centralise all data in a single contiguous buffer to improve CPU cache locality.
   - I'm hypothesizing that spreading data across memory via `Rc<_>` isn't great.
   - Instantiating new heap allocations for e.g. `Vec` when creating a new 2-element tuple seems wasteful
- Since the scripts are at most a few seconds in runtime, do we really need to garbage collect?

Lo and behold, IDK if it's faster:
- Day 11 has ~2s -> ~2.5s. Slower.
- Day 1 has ~290ms -> ~190ms. Faster

This change requires a LOT of lifetimes. But if it's not even faster, then I might just discard this PR and keep the simpler current model.