### PR TITLE
Add specialized stack-allocated 2D vector type as an optimized tuple variant

### DIFF
--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -465,7 +465,9 @@ where
             Bytecode::ToTuple => stdlib_fn!(self, to_tuple),
             Bytecode::CreateTuple(size) => {
                 let value = if *size == 2 {
-                    RuntimeValue::from((self.pop_stack(), self.pop_stack()))
+                    let b = self.pop_stack();
+                    let a = self.pop_stack();
+                    RuntimeValue::from((a, b))
                 } else {
                     let items = self.pop_args(*size);
                     RuntimeValue::Tuple(RuntimeTuple::from_vec(items))

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -449,7 +449,7 @@ where
                     RuntimeValue::from((a, b))
                 } else {
                     let items = self.pop_args(*size);
-                    RuntimeValue::Tuple(RuntimeTuple::from_vec(items))
+                    RuntimeValue::Tuple(RuntimeTuple::from_vec_inner(items))
                 };
                 self.push_stack(value);
             }

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -10,10 +10,8 @@ use crate::{
         bytecode::Bytecode,
         runtime_value::{
             function::{MemoizationKey, RuntimeFunction},
-            number::RuntimeNumber,
             string::RuntimeString,
             tuple::RuntimeTuple,
-            vec2::RuntimeVec2,
             RuntimeValue,
         },
     },
@@ -443,6 +441,19 @@ where
             }
 
             Bytecode::ToIter => unary_mapper_method!(self, to_iter),
+
+            Bytecode::CreateTuple(size) => {
+                let value = if *size == 2 {
+                    let b = self.pop_stack();
+                    let a = self.pop_stack();
+                    RuntimeValue::from((a, b))
+                } else {
+                    let items = self.pop_args(*size);
+                    RuntimeValue::Tuple(RuntimeTuple::from_vec(items))
+                };
+                self.push_stack(value);
+            }
+
             Bytecode::ToUpperCase => unary_mapper_method!(self, to_uppercase),
             Bytecode::ToLowerCase => unary_mapper_method!(self, to_lowercase),
             Bytecode::Split => binary_op!(self, split),
@@ -463,17 +474,6 @@ where
             Bytecode::ParseInt => stdlib_fn!(self, parse_int),
             Bytecode::ToList => stdlib_fn!(self, to_list),
             Bytecode::ToTuple => stdlib_fn!(self, to_tuple),
-            Bytecode::CreateTuple(size) => {
-                let value = if *size == 2 {
-                    let b = self.pop_stack();
-                    let a = self.pop_stack();
-                    RuntimeValue::from((a, b))
-                } else {
-                    let items = self.pop_args(*size);
-                    RuntimeValue::Tuple(RuntimeTuple::from_vec(items))
-                };
-                self.push_stack(value);
-            }
             Bytecode::ToMap => stdlib_fn!(self, to_map),
             Bytecode::MapWithDefault => stdlib_fn!(self, map_with_default),
             Bytecode::ToSet(num_args) => stdlib_fn_with_optional_arg!(self, to_set, *num_args),

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -473,8 +473,11 @@ where
                     let v2 = self.stack[len - 1].clone();
 
                     // Check if both are SmallInt - if so, create Vec2 directly
-                    if let (RuntimeValue::Num(RuntimeNumber::SmallInt(x)),
-                            RuntimeValue::Num(RuntimeNumber::SmallInt(y))) = (&v1, &v2) {
+                    if let (
+                        RuntimeValue::Num(RuntimeNumber::SmallInt(x)),
+                        RuntimeValue::Num(RuntimeNumber::SmallInt(y)),
+                    ) = (&v1, &v2)
+                    {
                         // Pop the two values
                         self.stack.truncate(len - 2);
                         // Push Vec2 directly

--- a/linefeed/src/vm.rs
+++ b/linefeed/src/vm.rs
@@ -481,7 +481,8 @@ where
                         // Pop the two values
                         self.stack.truncate(len - 2);
                         // Push Vec2 directly
-                        self.push_stack(RuntimeValue::Vec2(RuntimeVec2::new(*x, *y)));
+                        // FIXME: don't cast to i32 blindly
+                        self.push_stack(RuntimeValue::Vec2(RuntimeVec2::new(*x as i32, *y as i32)));
                     } else {
                         // Fall back to tuple creation
                         let items = self.pop_args(*size);

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -119,7 +119,6 @@ pub enum Bytecode {
 }
 
 const _: () = {
-    // Size increased from 16 to 24 bytes due to RuntimeValue growth (Vec2 addition)
     const SIZE: usize = std::mem::size_of::<Bytecode>();
     assert!(SIZE == 16);
 };

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -121,7 +121,7 @@ pub enum Bytecode {
 const _: () = {
     // Size increased from 16 to 24 bytes due to RuntimeValue growth (Vec2 addition)
     const SIZE: usize = std::mem::size_of::<Bytecode>();
-    assert!(SIZE == 24);
+    assert!(SIZE == 16);
 };
 
 impl Bytecode {

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -119,8 +119,9 @@ pub enum Bytecode {
 }
 
 const _: () = {
+    // Size increased from 16 to 24 bytes due to RuntimeValue growth (Vec2 addition)
     const SIZE: usize = std::mem::size_of::<Bytecode>();
-    assert!(SIZE == 16);
+    assert!(SIZE == 24);
 };
 
 impl Bytecode {
@@ -253,7 +254,8 @@ impl Bytecode {
                     .map(|item| Self::into_runtime_value_with_mapper(item, label_mapper))
                     .collect::<Result<_, _>>()?;
 
-                RuntimeValue::Tuple(RuntimeTuple::from_vec(items))
+                // Use optimized version that converts to Vec2 when possible
+                RuntimeTuple::from_vec_optimized(items)
             }
             IrValue::Set(xs) => {
                 let items = xs

--- a/linefeed/src/vm/bytecode.rs
+++ b/linefeed/src/vm/bytecode.rs
@@ -253,8 +253,7 @@ impl Bytecode {
                     .map(|item| Self::into_runtime_value_with_mapper(item, label_mapper))
                     .collect::<Result<_, _>>()?;
 
-                // Use optimized version that converts to Vec2 when possible
-                RuntimeTuple::from_vec_optimized(items)
+                RuntimeTuple::from_vec(items)
             }
             IrValue::Set(xs) => {
                 let items = xs

--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -36,8 +36,8 @@ pub mod regex;
 pub mod set;
 pub mod string;
 pub mod tuple;
-pub mod vec2;
 mod utils;
+pub mod vec2;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RuntimeValue {
@@ -520,7 +520,7 @@ impl std::fmt::Display for RuntimeValue {
                 write!(f, ")")
             }
             RuntimeValue::Vec2(v) => {
-                write!(f, "({}, {})", v.x, v.y)
+                write!(f, "v({}, {})", v.x, v.y)
             }
             RuntimeValue::Set(xs) => {
                 write!(f, "{{")?;

--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -520,7 +520,7 @@ impl std::fmt::Display for RuntimeValue {
                 write!(f, ")")
             }
             RuntimeValue::Vec2(v) => {
-                write!(f, "v({}, {})", v.x, v.y)
+                write!(f, "({}, {})", v.x, v.y)
             }
             RuntimeValue::Set(xs) => {
                 write!(f, "{{")?;
@@ -789,6 +789,13 @@ impl RuntimeValue {
                 "Expected number, found '{}'",
                 self.kind_str()
             ))),
+        }
+    }
+
+    pub fn to_i32(&self) -> Option<i32> {
+        match self {
+            RuntimeValue::Num(n) => n.to_i32(),
+            _ => None,
         }
     }
 }

--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -102,7 +102,7 @@ impl RuntimeValue {
             (RuntimeValue::Tuple(a), RuntimeValue::Tuple(b)) => {
                 Ok(RuntimeValue::Tuple(a.element_wise_add(b)?))
             }
-            (RuntimeValue::Vec2(v1), RuntimeValue::Vec2(v2)) => Ok(v1.add(v2)),
+            (RuntimeValue::Vec2(v1), RuntimeValue::Vec2(v2)) => v1.add(v2),
             (RuntimeValue::Vec2(v), RuntimeValue::Tuple(t)) => {
                 let vec_as_tuple = v.to_tuple();
                 Ok(RuntimeValue::Tuple(vec_as_tuple.element_wise_add(t)?))
@@ -124,7 +124,7 @@ impl RuntimeValue {
             (RuntimeValue::Tuple(a), RuntimeValue::Tuple(b)) => {
                 Ok(RuntimeValue::Tuple(a.element_wise_sub(b)?))
             }
-            (RuntimeValue::Vec2(v1), RuntimeValue::Vec2(v2)) => Ok(v1.sub(v2)),
+            (RuntimeValue::Vec2(v1), RuntimeValue::Vec2(v2)) => v1.sub(v2),
             (RuntimeValue::Vec2(v), RuntimeValue::Tuple(t)) => {
                 let vec_as_tuple = v.to_tuple();
                 Ok(RuntimeValue::Tuple(vec_as_tuple.element_wise_sub(t)?))

--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -161,7 +161,6 @@ impl RuntimeValue {
         match (self, other) {
             (RuntimeValue::Int(a), RuntimeValue::Int(b)) => Ok(RuntimeValue::Int(a / b)),
             (RuntimeValue::Num(a), RuntimeValue::Num(b)) => Ok(RuntimeValue::Num(a / b)),
-            (RuntimeValue::Vec2(v), _) => v.scalar_div(other),
             _ => Err(RuntimeError::invalid_binary_op_for_types(
                 "divide", self, other,
             )),
@@ -172,10 +171,6 @@ impl RuntimeValue {
         match (self, other) {
             (RuntimeValue::Int(a), RuntimeValue::Int(b)) => Ok(RuntimeValue::Int(a / b)),
             (RuntimeValue::Num(a), RuntimeValue::Num(b)) => Ok(RuntimeValue::Num(a.div_floor(b))),
-            (RuntimeValue::Vec2(v), _) => {
-                // For floor division, we use regular div which handles fallback to tuple if needed
-                v.scalar_div(other)
-            }
             _ => Err(RuntimeError::invalid_binary_op_for_types(
                 "divide", self, other,
             )),
@@ -186,7 +181,6 @@ impl RuntimeValue {
         match (self, other) {
             (RuntimeValue::Int(a), RuntimeValue::Int(b)) => Ok(RuntimeValue::Int(a % b)),
             (RuntimeValue::Num(a), RuntimeValue::Num(b)) => Ok(RuntimeValue::Num(a.modulo(b))),
-            (RuntimeValue::Vec2(v), _) => v.scalar_rem(other),
             _ => Err(RuntimeError::invalid_binary_op_for_types(
                 "modulo", self, other,
             )),

--- a/linefeed/src/vm/runtime_value.rs
+++ b/linefeed/src/vm/runtime_value.rs
@@ -64,7 +64,7 @@ const _: () = {
     // cloning super expensive.
     // Note: Size increased from 16 to 24 bytes to accommodate inline Vec2 (2 x isize = 16 bytes)
     const SIZE: usize = std::mem::size_of::<RuntimeValue>();
-    assert!(SIZE == 24);
+    assert!(SIZE == 16);
 };
 
 impl RuntimeValue {

--- a/linefeed/src/vm/runtime_value/iterator.rs
+++ b/linefeed/src/vm/runtime_value/iterator.rs
@@ -138,7 +138,8 @@ impl Iterator for EnumeratedListIterator {
     fn next(&mut self) -> Option<Self::Item> {
         let value = self.list.as_slice().get(self.index).cloned()?;
         let index_val = RuntimeValue::Num(RuntimeNumber::from(self.index));
-        let enumerated = RuntimeValue::Tuple(RuntimeTuple::from_vec(vec![index_val, value]));
+        // Use From implementation to automatically optimize to Vec2 when possible
+        let enumerated = RuntimeValue::from((index_val, value));
         self.index += 1;
         Some(enumerated)
     }

--- a/linefeed/src/vm/runtime_value/iterator.rs
+++ b/linefeed/src/vm/runtime_value/iterator.rs
@@ -138,7 +138,6 @@ impl Iterator for EnumeratedListIterator {
     fn next(&mut self) -> Option<Self::Item> {
         let value = self.list.as_slice().get(self.index).cloned()?;
         let index_val = RuntimeValue::Num(RuntimeNumber::from(self.index));
-        // Use From implementation to automatically optimize to Vec2 when possible
         let enumerated = RuntimeValue::from((index_val, value));
         self.index += 1;
         Some(enumerated)

--- a/linefeed/src/vm/runtime_value/map.rs
+++ b/linefeed/src/vm/runtime_value/map.rs
@@ -4,9 +4,7 @@ use ouroboros::self_referencing;
 use rustc_hash::FxHashMap;
 
 use crate::vm::{
-    runtime_value::{
-        iterator::RuntimeIterator, number::RuntimeNumber, tuple::RuntimeTuple, RuntimeValue,
-    },
+    runtime_value::{iterator::RuntimeIterator, number::RuntimeNumber, RuntimeValue},
     RuntimeError,
 };
 
@@ -216,6 +214,7 @@ impl Iterator for MapIterator {
     fn next(&mut self) -> Option<Self::Item> {
         self.cell
             .with_iter_mut(|it| it.next())
-            .map(|(k, v)| RuntimeValue::Tuple(RuntimeTuple::from_vec(vec![k.clone(), v.clone()])))
+            // Use From implementation to automatically optimize to Vec2 when possible
+            .map(|(k, v)| RuntimeValue::from((k.clone(), v.clone())))
     }
 }

--- a/linefeed/src/vm/runtime_value/map.rs
+++ b/linefeed/src/vm/runtime_value/map.rs
@@ -214,7 +214,6 @@ impl Iterator for MapIterator {
     fn next(&mut self) -> Option<Self::Item> {
         self.cell
             .with_iter_mut(|it| it.next())
-            // Use From implementation to automatically optimize to Vec2 when possible
             .map(|(k, v)| RuntimeValue::from((k.clone(), v.clone())))
     }
 }

--- a/linefeed/src/vm/runtime_value/number.rs
+++ b/linefeed/src/vm/runtime_value/number.rs
@@ -17,23 +17,11 @@ impl RuntimeNumber {
         }
     }
 
-    pub fn try_into_i32(&self) -> Option<i32> {
+    pub fn to_i32(&self) -> Option<i32> {
         match self {
-            SmallInt(i) => {
-                if *i >= i32::MIN as isize && *i <= i32::MAX as isize {
-                    Some(*i as i32)
-                } else {
-                    None
-                }
-            }
+            SmallInt(i) => i32::try_from(*i).ok(),
             BigInt(i) => i.to_i32(),
-            Float(f) => {
-                let floored = f.floor();
-                if floored < (i32::MIN as f64) || floored > (i32::MAX as f64) {
-                    return None;
-                }
-                Some(floored as i32)
-            }
+            _ => None,
         }
     }
 

--- a/linefeed/src/vm/runtime_value/number.rs
+++ b/linefeed/src/vm/runtime_value/number.rs
@@ -17,6 +17,26 @@ impl RuntimeNumber {
         }
     }
 
+    pub fn try_into_i32(&self) -> Option<i32> {
+        match self {
+            SmallInt(i) => {
+                if *i >= i32::MIN as isize && *i <= i32::MAX as isize {
+                    Some(*i as i32)
+                } else {
+                    None
+                }
+            }
+            BigInt(i) => i.to_i32(),
+            Float(f) => {
+                let floored = f.floor();
+                if floored < (i32::MIN as f64) || floored > (i32::MAX as f64) {
+                    return None;
+                }
+                Some(floored as i32)
+            }
+        }
+    }
+
     pub fn floor(&self) -> Self {
         match self {
             SmallInt(i) => SmallInt(*i),

--- a/linefeed/src/vm/runtime_value/regex.rs
+++ b/linefeed/src/vm/runtime_value/regex.rs
@@ -93,7 +93,7 @@ impl RuntimeRegex {
         let full_match = group_values.remove(0);
         group_values.push(full_match);
 
-        RuntimeValue::Tuple(RuntimeTuple::from_vec(group_values))
+        RuntimeTuple::from_vec(group_values)
     }
 }
 

--- a/linefeed/src/vm/runtime_value/tuple.rs
+++ b/linefeed/src/vm/runtime_value/tuple.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use crate::vm::{
-    runtime_value::{number::RuntimeNumber, utils::resolve_index, RuntimeValue},
+    runtime_value::{number::RuntimeNumber, utils::resolve_index, vec2::RuntimeVec2, RuntimeValue},
     RuntimeError,
 };
 
@@ -11,6 +11,20 @@ pub struct RuntimeTuple(Rc<Vec<RuntimeValue>>);
 impl RuntimeTuple {
     pub fn from_vec(vec: Vec<RuntimeValue>) -> Self {
         Self(Rc::new(vec))
+    }
+
+    /// Creates a RuntimeValue from a vec, optimizing 2-element small integer tuples to Vec2
+    pub fn from_vec_optimized(vec: Vec<RuntimeValue>) -> RuntimeValue {
+        // Try to optimize to Vec2 if it's a 2-element tuple with small integers
+        if vec.len() == 2 {
+            if let (Some(v1), Some(v2)) = (vec.get(0), vec.get(1)) {
+                if let Ok(vec2) = RuntimeVec2::try_from((v1.clone(), v2.clone())) {
+                    return RuntimeValue::Vec2(vec2);
+                }
+            }
+        }
+        // Otherwise, create a regular tuple
+        RuntimeValue::Tuple(Self::from_vec(vec))
     }
 
     pub fn as_slice(&self) -> &[RuntimeValue] {

--- a/linefeed/src/vm/runtime_value/vec2.rs
+++ b/linefeed/src/vm/runtime_value/vec2.rs
@@ -1,0 +1,223 @@
+use crate::vm::runtime_error::RuntimeError;
+use crate::vm::runtime_value::{RuntimeNumber, RuntimeTuple, RuntimeValue};
+
+/// Stack-allocated 2D vector optimized for small integer coordinates.
+/// Gracefully falls back to RuntimeTuple when operations overflow or encounter type mismatches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RuntimeVec2 {
+    pub x: isize,
+    pub y: isize,
+}
+
+impl RuntimeVec2 {
+    /// Creates a new Vec2
+    pub fn new(x: isize, y: isize) -> Self {
+        Self { x, y }
+    }
+
+    /// Converts this Vec2 to a RuntimeTuple
+    pub fn to_tuple(&self) -> RuntimeTuple {
+        RuntimeTuple::from_vec(vec![
+            RuntimeValue::Num(RuntimeNumber::SmallInt(self.x)),
+            RuntimeValue::Num(RuntimeNumber::SmallInt(self.y)),
+        ])
+    }
+
+    /// Attempts to add two Vec2 values, falling back to tuple addition on overflow
+    pub fn add(&self, other: &Self) -> RuntimeValue {
+        match (self.x.checked_add(other.x), self.y.checked_add(other.y)) {
+            (Some(x), Some(y)) => RuntimeValue::Vec2(RuntimeVec2::new(x, y)),
+            _ => {
+                // Overflow occurred, fall back to tuple addition
+                let t1 = self.to_tuple();
+                let t2 = other.to_tuple();
+                // element_wise_add cannot fail for valid tuples of same length
+                RuntimeValue::Tuple(t1.element_wise_add(&t2).unwrap())
+            }
+        }
+    }
+
+    /// Attempts to subtract two Vec2 values, falling back to tuple subtraction on overflow
+    pub fn sub(&self, other: &Self) -> RuntimeValue {
+        match (self.x.checked_sub(other.x), self.y.checked_sub(other.y)) {
+            (Some(x), Some(y)) => RuntimeValue::Vec2(RuntimeVec2::new(x, y)),
+            _ => {
+                // Overflow occurred, fall back to tuple subtraction
+                let t1 = self.to_tuple();
+                let t2 = other.to_tuple();
+                RuntimeValue::Tuple(t1.element_wise_sub(&t2).unwrap())
+            }
+        }
+    }
+
+    /// Attempts to multiply Vec2 by a scalar, falling back to tuple multiplication on overflow
+    pub fn scalar_mul(&self, scalar: &RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
+        // Extract the scalar value
+        let RuntimeValue::Num(num) = scalar else {
+            // Not a number, fall back to tuple
+            let tuple = self.to_tuple();
+            return Ok(RuntimeValue::Tuple(tuple.scalar_multiply(scalar)?));
+        };
+
+        match num {
+            RuntimeNumber::SmallInt(s) => {
+                // Try checked multiplication
+                match (self.x.checked_mul(*s), self.y.checked_mul(*s)) {
+                    (Some(new_x), Some(new_y)) => Ok(RuntimeValue::Vec2(RuntimeVec2::new(new_x, new_y))),
+                    _ => {
+                        // Overflow, fall back to tuple
+                        let tuple = self.to_tuple();
+                        Ok(RuntimeValue::Tuple(tuple.scalar_multiply(scalar)?))
+                    }
+                }
+            }
+            _ => {
+                // BigInt or Float, fall back to tuple
+                let tuple = self.to_tuple();
+                Ok(RuntimeValue::Tuple(tuple.scalar_multiply(scalar)?))
+            }
+        }
+    }
+
+    /// Attempts to divide Vec2 by a scalar, falling back to tuple division on overflow or non-integer result
+    pub fn scalar_div(&self, scalar: &RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
+        // Extract the scalar value
+        let RuntimeValue::Num(num) = scalar else {
+            // Not a number, convert to tuple and delegate
+            let tuple = self.to_tuple();
+            let tuple_val = RuntimeValue::Tuple(tuple);
+            return tuple_val.div(scalar);
+        };
+
+        match num {
+            RuntimeNumber::SmallInt(s) => {
+                if *s == 0 {
+                    return Err(RuntimeError::Plain("Division by zero".to_string()));
+                }
+                // Try checked division - only succeeds if result is exact
+                if self.x % s == 0 && self.y % s == 0 {
+                    Ok(RuntimeValue::Vec2(RuntimeVec2::new(self.x / s, self.y / s)))
+                } else {
+                    // Non-integer result, fall back to tuple (which will produce floats)
+                    let tuple = self.to_tuple();
+                    let tuple_val = RuntimeValue::Tuple(tuple);
+                    tuple_val.div(scalar)
+                }
+            }
+            _ => {
+                // BigInt or Float, fall back to tuple
+                let tuple = self.to_tuple();
+                let tuple_val = RuntimeValue::Tuple(tuple);
+                tuple_val.div(scalar)
+            }
+        }
+    }
+
+    /// Attempts to compute Vec2 modulo a scalar
+    pub fn scalar_rem(&self, scalar: &RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
+        // Extract the scalar value
+        let RuntimeValue::Num(RuntimeNumber::SmallInt(s)) = scalar else {
+            // Not a small int, fall back to tuple
+            let tuple = self.to_tuple();
+            let tuple_val = RuntimeValue::Tuple(tuple);
+            return tuple_val.modulo(scalar);
+        };
+
+        if *s == 0 {
+            return Err(RuntimeError::Plain("Division by zero".to_string()));
+        }
+
+        Ok(RuntimeValue::Vec2(RuntimeVec2::new(self.x % s, self.y % s)))
+    }
+
+    /// Rotates this Vec2 by 90-degree increments (clockwise)
+    /// Same logic as RuntimeTuple::rot but optimized for Vec2
+    pub fn rot(&self, times: &RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
+        let RuntimeValue::Num(RuntimeNumber::SmallInt(n)) = times else {
+            // Not a small int, fall back to tuple
+            let tuple = self.to_tuple();
+            return tuple.rot(times).map(RuntimeValue::Tuple);
+        };
+
+        // Normalize to 0-3 range (4 rotations = 360 degrees = identity)
+        let normalized = n.rem_euclid(4);
+
+        match normalized {
+            0 => Ok(RuntimeValue::Vec2(*self)),           // No rotation
+            1 => Ok(RuntimeValue::Vec2(RuntimeVec2::new(self.y, -self.x))),  // 90 degrees clockwise
+            2 => Ok(RuntimeValue::Vec2(RuntimeVec2::new(-self.x, -self.y))), // 180 degrees
+            3 => Ok(RuntimeValue::Vec2(RuntimeVec2::new(-self.y, self.x))),  // 270 degrees clockwise (= 90 ccw)
+            _ => unreachable!("rem_euclid(4) should only return 0-3"),
+        }
+    }
+
+    /// Gets an element from Vec2 by index
+    pub fn index(&self, index: &RuntimeNumber) -> Result<RuntimeValue, RuntimeError> {
+        let RuntimeNumber::SmallInt(idx) = index else {
+            return Err(RuntimeError::TypeMismatch("Invalid index type".to_string()));
+        };
+
+        // Support negative indexing
+        let normalized_idx = if *idx < 0 {
+            2 + idx
+        } else {
+            *idx
+        };
+
+        match normalized_idx {
+            0 => Ok(RuntimeValue::Num(RuntimeNumber::SmallInt(self.x))),
+            1 => Ok(RuntimeValue::Num(RuntimeNumber::SmallInt(self.y))),
+            _ => Err(RuntimeError::IndexOutOfBounds(*idx, 2)),
+        }
+    }
+
+    /// Checks if Vec2 contains a value
+    pub fn contains(&self, value: &RuntimeValue) -> bool {
+        let RuntimeValue::Num(RuntimeNumber::SmallInt(v)) = value else {
+            return false;
+        };
+        self.x == *v || self.y == *v
+    }
+
+    /// Compares two Vec2 values lexicographically
+    pub fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.x.cmp(&other.x) {
+            std::cmp::Ordering::Equal => self.y.cmp(&other.y),
+            other => other,
+        }
+    }
+
+    /// Returns the length (number of elements) of this Vec2
+    pub fn len(&self) -> usize {
+        2
+    }
+}
+
+/// Try to create a RuntimeVec2 from two RuntimeValues
+/// Returns None if either value is not a SmallInt
+impl TryFrom<(RuntimeValue, RuntimeValue)> for RuntimeVec2 {
+    type Error = ();
+
+    fn try_from((v1, v2): (RuntimeValue, RuntimeValue)) -> Result<Self, Self::Error> {
+        match (v1, v2) {
+            (RuntimeValue::Num(RuntimeNumber::SmallInt(x)), RuntimeValue::Num(RuntimeNumber::SmallInt(y))) => {
+                Ok(RuntimeVec2::new(x, y))
+            }
+            _ => Err(()),
+        }
+    }
+}
+
+/// Create a RuntimeValue from two RuntimeValues
+/// Tries to create a Vec2 if both are SmallInts, otherwise creates a Tuple
+impl From<(RuntimeValue, RuntimeValue)> for RuntimeValue {
+    fn from((v1, v2): (RuntimeValue, RuntimeValue)) -> Self {
+        // Try to create Vec2 first
+        if let Ok(vec2) = RuntimeVec2::try_from((v1.clone(), v2.clone())) {
+            RuntimeValue::Vec2(vec2)
+        } else {
+            // Fall back to tuple
+            RuntimeValue::Tuple(RuntimeTuple::from_vec(vec![v1, v2]))
+        }
+    }
+}

--- a/linefeed/src/vm/runtime_value/vec2.rs
+++ b/linefeed/src/vm/runtime_value/vec2.rs
@@ -27,7 +27,7 @@ impl RuntimeVec2 {
     }
 
     pub fn to_tuple(&self) -> RuntimeTuple {
-        RuntimeTuple::from_vec(vec![
+        RuntimeTuple::from_vec_inner(vec![
             RuntimeValue::Num(RuntimeNumber::SmallInt(self.x as isize)),
             RuntimeValue::Num(RuntimeNumber::SmallInt(self.y as isize)),
         ])
@@ -142,6 +142,6 @@ impl From<(RuntimeValue, RuntimeValue)> for RuntimeValue {
     fn from((v1, v2): (RuntimeValue, RuntimeValue)) -> Self {
         RuntimeVec2::try_from((&v1, &v2))
             .map(RuntimeValue::Vec2)
-            .unwrap_or_else(|_| RuntimeValue::Tuple(RuntimeTuple::from_vec(vec![v1, v2])))
+            .unwrap_or_else(|_| RuntimeValue::Tuple(RuntimeTuple::from_vec_inner(vec![v1, v2])))
     }
 }

--- a/linefeed/src/vm/runtime_value/vec2.rs
+++ b/linefeed/src/vm/runtime_value/vec2.rs
@@ -24,28 +24,27 @@ impl RuntimeVec2 {
     }
 
     /// Attempts to add two Vec2 values, falling back to tuple addition on overflow
-    pub fn add(&self, other: &Self) -> RuntimeValue {
+    pub fn add(&self, other: &Self) -> Result<RuntimeValue, RuntimeError> {
         match (self.x.checked_add(other.x), self.y.checked_add(other.y)) {
-            (Some(x), Some(y)) => RuntimeValue::Vec2(RuntimeVec2::new(x, y)),
+            (Some(x), Some(y)) => Ok(RuntimeValue::Vec2(RuntimeVec2::new(x, y))),
             _ => {
                 // Overflow occurred, fall back to tuple addition
                 let t1 = self.to_tuple();
                 let t2 = other.to_tuple();
-                // element_wise_add cannot fail for valid tuples of same length
-                RuntimeValue::Tuple(t1.element_wise_add(&t2).unwrap())
+                Ok(RuntimeValue::Tuple(t1.element_wise_add(&t2)?))
             }
         }
     }
 
     /// Attempts to subtract two Vec2 values, falling back to tuple subtraction on overflow
-    pub fn sub(&self, other: &Self) -> RuntimeValue {
+    pub fn sub(&self, other: &Self) -> Result<RuntimeValue, RuntimeError> {
         match (self.x.checked_sub(other.x), self.y.checked_sub(other.y)) {
-            (Some(x), Some(y)) => RuntimeValue::Vec2(RuntimeVec2::new(x, y)),
+            (Some(x), Some(y)) => Ok(RuntimeValue::Vec2(RuntimeVec2::new(x, y))),
             _ => {
                 // Overflow occurred, fall back to tuple subtraction
                 let t1 = self.to_tuple();
                 let t2 = other.to_tuple();
-                RuntimeValue::Tuple(t1.element_wise_sub(&t2).unwrap())
+                Ok(RuntimeValue::Tuple(t1.element_wise_sub(&t2)?))
             }
         }
     }

--- a/linefeed/src/vm/runtime_value/vec2.rs
+++ b/linefeed/src/vm/runtime_value/vec2.rs
@@ -9,13 +9,23 @@ pub struct RuntimeVec2 {
     pub y: i32,
 }
 
+macro_rules! unwrap_or_fallback {
+    ($opt:expr, $self:expr, $method:ident $(, $arg:expr)*) => {
+        match $opt {
+            Some(res) => res,
+            None => {
+                let tuple = $self.to_tuple();
+                return Ok(RuntimeValue::Tuple(tuple.$method($($arg),*)?));
+            }
+        }
+    };
+}
+
 impl RuntimeVec2 {
-    /// Creates a new Vec2
     pub fn new(x: i32, y: i32) -> Self {
         Self { x, y }
     }
 
-    /// Converts this Vec2 to a RuntimeTuple
     pub fn to_tuple(&self) -> RuntimeTuple {
         RuntimeTuple::from_vec(vec![
             RuntimeValue::Num(RuntimeNumber::SmallInt(self.x as isize)),
@@ -23,157 +33,89 @@ impl RuntimeVec2 {
         ])
     }
 
-    /// Attempts to add two Vec2 values, falling back to tuple addition on overflow
     pub fn add(&self, other: &Self) -> Result<RuntimeValue, RuntimeError> {
-        match (self.x.checked_add(other.x), self.y.checked_add(other.y)) {
-            (Some(x), Some(y)) => Ok(RuntimeValue::Vec2(RuntimeVec2::new(x, y))),
-            _ => {
-                // Overflow occurred, fall back to tuple addition
-                let t1 = self.to_tuple();
-                let t2 = other.to_tuple();
-                Ok(RuntimeValue::Tuple(t1.element_wise_add(&t2)?))
-            }
-        }
+        let res = self.x.checked_add(other.x).zip(self.y.checked_add(other.y));
+
+        let (x, y) = unwrap_or_fallback!(res, self, element_wise_add, &other.to_tuple());
+
+        Ok(RuntimeValue::Vec2(RuntimeVec2::new(x, y)))
     }
 
-    /// Attempts to subtract two Vec2 values, falling back to tuple subtraction on overflow
     pub fn sub(&self, other: &Self) -> Result<RuntimeValue, RuntimeError> {
-        match (self.x.checked_sub(other.x), self.y.checked_sub(other.y)) {
-            (Some(x), Some(y)) => Ok(RuntimeValue::Vec2(RuntimeVec2::new(x, y))),
-            _ => {
-                // Overflow occurred, fall back to tuple subtraction
-                let t1 = self.to_tuple();
-                let t2 = other.to_tuple();
-                Ok(RuntimeValue::Tuple(t1.element_wise_sub(&t2)?))
-            }
-        }
+        let res = self.x.checked_sub(other.x).zip(self.y.checked_sub(other.y));
+
+        let (x, y) = unwrap_or_fallback!(res, self, element_wise_sub, &other.to_tuple());
+
+        Ok(RuntimeValue::Vec2(RuntimeVec2::new(x, y)))
     }
 
-    /// Attempts to multiply Vec2 by a scalar, falling back to tuple multiplication on overflow
     pub fn scalar_mul(&self, scalar: &RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
-        match scalar.to_i32() {
-            Some(s) => {
-                // Try checked multiplication
-                match (self.x.checked_mul(s), self.y.checked_mul(s)) {
-                    (Some(new_x), Some(new_y)) => {
-                        Ok(RuntimeValue::Vec2(RuntimeVec2::new(new_x, new_y)))
-                    }
-                    _ => {
-                        // Overflow, fall back to tuple
-                        let tuple = self.to_tuple();
-                        Ok(RuntimeValue::Tuple(tuple.scalar_multiply(scalar)?))
-                    }
-                }
-            }
-            None => {
-                // Not a number, BigInt, or Float - fall back to tuple
-                let tuple = self.to_tuple();
-                Ok(RuntimeValue::Tuple(tuple.scalar_multiply(scalar)?))
-            }
-        }
+        let res = scalar
+            .to_i32()
+            .and_then(|s| self.x.checked_mul(s).zip(self.y.checked_mul(s)));
+
+        let (x, y) = unwrap_or_fallback!(res, self, scalar_multiply, scalar);
+
+        Ok(RuntimeValue::Vec2(RuntimeVec2::new(x, y)))
     }
 
-    /// Attempts to divide Vec2 by a scalar, falling back to tuple division on overflow or non-integer result
-    pub fn scalar_div(&self, scalar: &RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
-        match scalar.to_i32() {
-            Some(s) => {
-                if s == 0 {
-                    return Err(RuntimeError::Plain("Division by zero".to_string()));
-                }
-                // Try checked division - only succeeds if result is exact
-                if self.x % s == 0 && self.y % s == 0 {
-                    Ok(RuntimeValue::Vec2(RuntimeVec2::new(self.x / s, self.y / s)))
-                } else {
-                    // Non-integer result, fall back to tuple (which will produce floats)
-                    let tuple = self.to_tuple();
-                    let tuple_val = RuntimeValue::Tuple(tuple);
-                    tuple_val.div(scalar)
-                }
-            }
-            None => {
-                // Not a number, BigInt, or Float - fall back to tuple
-                let tuple = self.to_tuple();
-                let tuple_val = RuntimeValue::Tuple(tuple);
-                tuple_val.div(scalar)
-            }
-        }
-    }
-
-    /// Attempts to compute Vec2 modulo a scalar
-    pub fn scalar_rem(&self, scalar: &RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
-        let s = match scalar.to_i32() {
-            Some(v) => v,
-            None => {
-                // Not a number, BigInt, or Float - fall back to tuple
-                let tuple = self.to_tuple();
-                let tuple_val = RuntimeValue::Tuple(tuple);
-                return tuple_val.modulo(scalar);
-            }
-        };
-
-        if s == 0 {
-            return Err(RuntimeError::Plain("Division by zero".to_string()));
-        }
-
-        Ok(RuntimeValue::Vec2(RuntimeVec2::new(self.x % s, self.y % s)))
-    }
-
-    /// Rotates this Vec2 by 90-degree increments (clockwise)
-    /// Same logic as RuntimeTuple::rot but optimized for Vec2
     pub fn rot(&self, times: &RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
-        let RuntimeValue::Num(RuntimeNumber::SmallInt(n)) = times else {
-            // Not a small int, fall back to tuple
-            let tuple = self.to_tuple();
-            return tuple.rot(times).map(RuntimeValue::Tuple);
+        let n = unwrap_or_fallback!(times.to_i32(), self, rot, times);
+
+        let rotated = match n.rem_euclid(4) {
+            0 => *self,                              // No rotation
+            1 => RuntimeVec2::new(self.y, -self.x),  // 90 degrees clockwise
+            2 => RuntimeVec2::new(-self.x, -self.y), // 180 degrees
+            3 => RuntimeVec2::new(-self.y, self.x),  // 270 degrees clockwise (= 90 ccw)
+            _ => unreachable!("rotations should only be 0-3"),
         };
 
-        // Normalize to 0-3 range (4 rotations = 360 degrees = identity)
-        let normalized = n.rem_euclid(4);
-
-        match normalized {
-            0 => Ok(RuntimeValue::Vec2(*self)), // No rotation
-            1 => Ok(RuntimeValue::Vec2(RuntimeVec2::new(self.y, -self.x))), // 90 degrees clockwise
-            2 => Ok(RuntimeValue::Vec2(RuntimeVec2::new(-self.x, -self.y))), // 180 degrees
-            3 => Ok(RuntimeValue::Vec2(RuntimeVec2::new(-self.y, self.x))), // 270 degrees clockwise (= 90 ccw)
-            _ => unreachable!("rem_euclid(4) should only return 0-3"),
-        }
+        Ok(RuntimeValue::Vec2(rotated))
     }
 
-    /// Gets an element from Vec2 by index
     pub fn index(&self, index: &RuntimeNumber) -> Result<RuntimeValue, RuntimeError> {
-        let RuntimeNumber::SmallInt(idx) = index else {
-            return Err(RuntimeError::TypeMismatch("Invalid index type".to_string()));
+        let idx = index
+            .to_i32()
+            .ok_or_else(|| RuntimeError::IndexOutOfBounds(index.floor_int(), 2))?;
+
+        let normalized_idx = if idx < 0 { 2 + idx } else { idx };
+        let val = match normalized_idx {
+            0 => self.x,
+            1 => self.y,
+            _ => return Err(RuntimeError::IndexOutOfBounds(idx as isize, 2)),
         };
 
-        // Support negative indexing
-        let normalized_idx = if *idx < 0 { 2 + idx } else { *idx };
-
-        match normalized_idx {
-            0 => Ok(RuntimeValue::Num(RuntimeNumber::SmallInt(self.x as isize))),
-            1 => Ok(RuntimeValue::Num(RuntimeNumber::SmallInt(self.y as isize))),
-            _ => Err(RuntimeError::IndexOutOfBounds(*idx, 2)),
-        }
+        Ok(RuntimeValue::Num(RuntimeNumber::SmallInt(val as isize)))
     }
 
-    /// Checks if Vec2 contains a value
     pub fn contains(&self, value: &RuntimeValue) -> bool {
-        let RuntimeValue::Num(RuntimeNumber::SmallInt(v)) = value else {
-            return false;
-        };
-        self.x as isize == *v || self.y as isize == *v
+        value
+            .to_i32()
+            .map(|v| self.x == v || self.y == v)
+            .unwrap_or(false)
     }
 
-    /// Compares two Vec2 values lexicographically
-    pub fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    pub fn len(&self) -> usize {
+        2
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl std::cmp::PartialOrd for RuntimeVec2 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for RuntimeVec2 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match self.x.cmp(&other.x) {
             std::cmp::Ordering::Equal => self.y.cmp(&other.y),
             other => other,
         }
-    }
-
-    /// Returns the length (number of elements) of this Vec2
-    pub fn len(&self) -> usize {
-        2
     }
 }
 

--- a/linefeed/src/vm/runtime_value/vec2.rs
+++ b/linefeed/src/vm/runtime_value/vec2.rs
@@ -52,14 +52,7 @@ impl RuntimeVec2 {
 
     /// Attempts to multiply Vec2 by a scalar, falling back to tuple multiplication on overflow
     pub fn scalar_mul(&self, scalar: &RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
-        // Extract the scalar value
-        let RuntimeValue::Num(num) = scalar else {
-            // Not a number, fall back to tuple
-            let tuple = self.to_tuple();
-            return Ok(RuntimeValue::Tuple(tuple.scalar_multiply(scalar)?));
-        };
-
-        match num.try_into_i32() {
+        match scalar.to_i32() {
             Some(s) => {
                 // Try checked multiplication
                 match (self.x.checked_mul(s), self.y.checked_mul(s)) {
@@ -73,8 +66,8 @@ impl RuntimeVec2 {
                     }
                 }
             }
-            _ => {
-                // BigInt or Float, fall back to tuple
+            None => {
+                // Not a number, BigInt, or Float - fall back to tuple
                 let tuple = self.to_tuple();
                 Ok(RuntimeValue::Tuple(tuple.scalar_multiply(scalar)?))
             }
@@ -83,15 +76,7 @@ impl RuntimeVec2 {
 
     /// Attempts to divide Vec2 by a scalar, falling back to tuple division on overflow or non-integer result
     pub fn scalar_div(&self, scalar: &RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
-        // Extract the scalar value
-        let RuntimeValue::Num(num) = scalar else {
-            // Not a number, convert to tuple and delegate
-            let tuple = self.to_tuple();
-            let tuple_val = RuntimeValue::Tuple(tuple);
-            return tuple_val.div(scalar);
-        };
-
-        match num.try_into_i32() {
+        match scalar.to_i32() {
             Some(s) => {
                 if s == 0 {
                     return Err(RuntimeError::Plain("Division by zero".to_string()));
@@ -106,8 +91,8 @@ impl RuntimeVec2 {
                     tuple_val.div(scalar)
                 }
             }
-            _ => {
-                // BigInt or Float, fall back to tuple
+            None => {
+                // Not a number, BigInt, or Float - fall back to tuple
                 let tuple = self.to_tuple();
                 let tuple_val = RuntimeValue::Tuple(tuple);
                 tuple_val.div(scalar)
@@ -117,17 +102,10 @@ impl RuntimeVec2 {
 
     /// Attempts to compute Vec2 modulo a scalar
     pub fn scalar_rem(&self, scalar: &RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
-        let RuntimeValue::Num(n) = scalar else {
-            // Not a small int, fall back to tuple
-            let tuple = self.to_tuple();
-            let tuple_val = RuntimeValue::Tuple(tuple);
-            return tuple_val.modulo(scalar);
-        };
-
-        let s = match n.try_into_i32() {
+        let s = match scalar.to_i32() {
             Some(v) => v,
             None => {
-                // BigInt or Float, fall back to tuple
+                // Not a number, BigInt, or Float - fall back to tuple
                 let tuple = self.to_tuple();
                 let tuple_val = RuntimeValue::Tuple(tuple);
                 return tuple_val.modulo(scalar);

--- a/linefeed/src/vm/stdlib.rs
+++ b/linefeed/src/vm/stdlib.rs
@@ -202,7 +202,7 @@ pub fn manhattan(args: Vec<RuntimeValue>) -> RuntimeResult {
         [RuntimeValue::Tuple(a), RuntimeValue::Tuple(b)] => a.element_wise_sub(b)?,
         [RuntimeValue::Vec2(a), RuntimeValue::Vec2(b)] => {
             // Subtract Vec2 values, convert result to tuple
-            match a.sub(b) {
+            match a.sub(b)? {
                 RuntimeValue::Vec2(result) => result.to_tuple(),
                 RuntimeValue::Tuple(t) => t,
                 _ => unreachable!("Vec2 subtraction should only produce Vec2 or Tuple"),

--- a/linefeed/src/vm/stdlib.rs
+++ b/linefeed/src/vm/stdlib.rs
@@ -50,7 +50,7 @@ pub fn to_tuple(val: RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
         )));
     };
 
-    Ok(RuntimeValue::Tuple(RuntimeTuple::from_vec(iter.to_vec())))
+    Ok(RuntimeTuple::from_vec_optimized(iter.to_vec()))
 }
 
 pub fn map_with_default(default_value: RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
@@ -208,12 +208,8 @@ pub fn manhattan(args: Vec<RuntimeValue>) -> RuntimeResult {
                 _ => unreachable!("Vec2 subtraction should only produce Vec2 or Tuple"),
             }
         }
-        [RuntimeValue::Vec2(v), RuntimeValue::Tuple(t)] => {
-            v.to_tuple().element_wise_sub(t)?
-        }
-        [RuntimeValue::Tuple(t), RuntimeValue::Vec2(v)] => {
-            t.element_wise_sub(&v.to_tuple())?
-        }
+        [RuntimeValue::Vec2(v), RuntimeValue::Tuple(t)] => v.to_tuple().element_wise_sub(t)?,
+        [RuntimeValue::Tuple(t), RuntimeValue::Vec2(v)] => t.element_wise_sub(&v.to_tuple())?,
         _ => {
             return Err(RuntimeError::TypeMismatch(format!(
                 "cannot calculate manhattan distance for arguments of types: {}",

--- a/linefeed/src/vm/stdlib.rs
+++ b/linefeed/src/vm/stdlib.rs
@@ -196,20 +196,15 @@ pub fn abs(val: RuntimeValue) -> RuntimeResult {
 }
 
 pub fn manhattan(args: Vec<RuntimeValue>) -> RuntimeResult {
-    let diff = match args.as_slice() {
-        [RuntimeValue::Tuple(t)] => t.clone(),
-        [RuntimeValue::Vec2(v)] => v.to_tuple(),
-        [RuntimeValue::Tuple(a), RuntimeValue::Tuple(b)] => a.element_wise_sub(b)?,
-        [RuntimeValue::Vec2(a), RuntimeValue::Vec2(b)] => {
-            // Subtract Vec2 values, convert result to tuple
-            match a.sub(b)? {
-                RuntimeValue::Vec2(result) => result.to_tuple(),
-                RuntimeValue::Tuple(t) => t,
-                _ => unreachable!("Vec2 subtraction should only produce Vec2 or Tuple"),
-            }
-        }
-        [RuntimeValue::Vec2(v), RuntimeValue::Tuple(t)] => v.to_tuple().element_wise_sub(t)?,
-        [RuntimeValue::Tuple(t), RuntimeValue::Vec2(v)] => t.element_wise_sub(&v.to_tuple())?,
+    let diff = match (args.first(), args.get(1)) {
+        (Some(a), None) => a.clone(),
+        (Some(a), Some(b)) => a.sub(b)?,
+        (None, _) => unreachable!("manhattan function called with no arguments"),
+    };
+
+    let diff = match diff {
+        RuntimeValue::Tuple(t) => t,
+        RuntimeValue::Vec2(v) => v.to_tuple(),
         _ => {
             return Err(RuntimeError::TypeMismatch(format!(
                 "cannot calculate manhattan distance for arguments of types: {}",

--- a/linefeed/src/vm/stdlib.rs
+++ b/linefeed/src/vm/stdlib.rs
@@ -198,7 +198,22 @@ pub fn abs(val: RuntimeValue) -> RuntimeResult {
 pub fn manhattan(args: Vec<RuntimeValue>) -> RuntimeResult {
     let diff = match args.as_slice() {
         [RuntimeValue::Tuple(t)] => t.clone(),
+        [RuntimeValue::Vec2(v)] => v.to_tuple(),
         [RuntimeValue::Tuple(a), RuntimeValue::Tuple(b)] => a.element_wise_sub(b)?,
+        [RuntimeValue::Vec2(a), RuntimeValue::Vec2(b)] => {
+            // Subtract Vec2 values, convert result to tuple
+            match a.sub(b) {
+                RuntimeValue::Vec2(result) => result.to_tuple(),
+                RuntimeValue::Tuple(t) => t,
+                _ => unreachable!("Vec2 subtraction should only produce Vec2 or Tuple"),
+            }
+        }
+        [RuntimeValue::Vec2(v), RuntimeValue::Tuple(t)] => {
+            v.to_tuple().element_wise_sub(t)?
+        }
+        [RuntimeValue::Tuple(t), RuntimeValue::Vec2(v)] => {
+            t.element_wise_sub(&v.to_tuple())?
+        }
         _ => {
             return Err(RuntimeError::TypeMismatch(format!(
                 "cannot calculate manhattan distance for arguments of types: {}",

--- a/linefeed/src/vm/stdlib.rs
+++ b/linefeed/src/vm/stdlib.rs
@@ -50,7 +50,7 @@ pub fn to_tuple(val: RuntimeValue) -> Result<RuntimeValue, RuntimeError> {
         )));
     };
 
-    Ok(RuntimeTuple::from_vec_optimized(iter.to_vec()))
+    Ok(RuntimeTuple::from_vec(iter.to_vec()))
 }
 
 pub fn map_with_default(default_value: RuntimeValue) -> Result<RuntimeValue, RuntimeError> {


### PR DESCRIPTION
Often, I use 2D tuples as coordinates in my AoC solutions (for navigating a grid or similar). In some cases, these tuples are created, hashed, added, copied, looked up, and so forth *many* times! Each lookup has to follow pointers as such: `Rc` (RuntimeTuple) -> `Vec` (RuntimeTuple) -> RuntimeValue for each index.

This PR introduces a specialized tuple variant, `Vec2`, which is suited for 2D tuples of integers and is stack-allocated and `Copy`, requiring no pointer indirection. Should result in less overhead, page faults, and better cache locality.

The specialized variant is automatically constructed when trying to create 2-element tuples by checking types and length during instantiation. All operations on `RuntimeVec` will automatically fall back to `RuntimeTuple` on `i32` overflows, type mismatches, or similar. As such, the `Vec2` variant is a runtime-applied optimization that falls back to standard "slow" tuple behaviour for complex/erroneous cases.

I observe the secret-input test for day 11 to go from ~1.85s to ~1.42s over a few runs, which is definitely an improvement! Especially considering a lot of time is spent on hashing and similar.

A little note about the integer size: `x` and `y` are `i32` (4 bytes each) so that `RuntimeVec` can fit in `8 bytes`, which allows for `RuntimeValue::Vec2(RuntimeVec)` to take up 16 bytes without indirection, allowing it to be stack-allocated directly without changing the size of `RuntimeValue` and `Bytecode`. An earlier version of this change used `i64`, which required `RuntimeValue` and `Bytecode` to be 24 bytes. Reducing the size to 16 bytes again made code run ~1.5-1.6s to ~1.4s.

This optimization also benefits other call-sites, such as enumerated list iterators. If it's a list of integers, the enumeration tuple `(i, value)` can now be stack-allocated and cheaply discarded when no longer in use rather than require heap-allocation and pointer indirection.

*Supersedes https://github.com/avborup/linefeed/pull/18 by applying the same idea a bit more ergonomically*